### PR TITLE
feat: incremental session compaction cache for chat transform

### DIFF
--- a/compact-cache.ts
+++ b/compact-cache.ts
@@ -1,0 +1,125 @@
+import type { CompactResult } from "@morphllm/morphsdk";
+
+export type CompactInputMessage = {
+  role: string;
+  content: string;
+  name?: string;
+};
+
+type CacheableMessage = {
+  info: {
+    sessionID: string;
+    id: string;
+  };
+};
+
+type ResultWithOutput = {
+  output: string;
+};
+
+export type SessionCompactCache<TResult = CompactResult> = {
+  sessionID: string;
+  firstMessageId: string;
+  lastMessageId: string;
+  messageCount: number;
+  result: TResult;
+};
+
+export function createBoundedCompactCache<TResult>(maxSize: number) {
+  const map = new Map<string, SessionCompactCache<TResult>>();
+
+  return {
+    get(sessionID: string): SessionCompactCache<TResult> | undefined {
+      const entry = map.get(sessionID);
+      if (entry) {
+        map.delete(sessionID);
+        map.set(sessionID, entry);
+      }
+      return entry;
+    },
+
+    set(sessionID: string, entry: SessionCompactCache<TResult>) {
+      map.delete(sessionID);
+      map.set(sessionID, entry);
+      if (map.size > maxSize) {
+        const oldest = map.keys().next().value;
+        if (oldest !== undefined) map.delete(oldest);
+      }
+    },
+
+    has(sessionID: string): boolean {
+      return map.has(sessionID);
+    },
+
+    size(): number {
+      return map.size;
+    },
+  };
+}
+
+export function buildCompactCacheEntry<
+  TMessage extends CacheableMessage,
+  TResult,
+>(
+  messages: TMessage[],
+  result: TResult,
+): SessionCompactCache<TResult> {
+  return {
+    sessionID: messages[0]!.info.sessionID,
+    firstMessageId: messages[0]!.info.id,
+    lastMessageId: messages[messages.length - 1]!.info.id,
+    messageCount: messages.length,
+    result,
+  };
+}
+
+export function canReuseCompactCache<TMessage extends CacheableMessage, TResult>(
+  cache: SessionCompactCache<TResult>,
+  messages: TMessage[],
+): boolean {
+  return (
+    cache.sessionID === messages[0]!.info.sessionID &&
+    cache.messageCount === messages.length &&
+    cache.firstMessageId === messages[0]!.info.id &&
+    cache.lastMessageId === messages[messages.length - 1]!.info.id
+  );
+}
+
+export function canExtendCompactCache<
+  TMessage extends CacheableMessage,
+  TResult,
+>(
+  cache: SessionCompactCache<TResult>,
+  messages: TMessage[],
+): boolean {
+  if (
+    cache.sessionID !== messages[0]!.info.sessionID ||
+    cache.messageCount >= messages.length ||
+    cache.firstMessageId !== messages[0]!.info.id
+  ) {
+    return false;
+  }
+
+  return messages[cache.messageCount - 1]?.info.id === cache.lastMessageId;
+}
+
+export function buildCachedCompactInput<TResult extends ResultWithOutput>(
+  cache: SessionCompactCache<TResult>,
+): CompactInputMessage {
+  return {
+    role: "user",
+    content: `[Morph Compact summary of ${cache.messageCount} earlier messages]\n\n${cache.result.output}`,
+  };
+}
+
+export function buildIncrementalCompactInput<
+  TMessage extends CacheableMessage,
+  TResult extends ResultWithOutput,
+>(
+  cache: SessionCompactCache<TResult>,
+  messages: TMessage[],
+  messagesToCompactInput: (messages: TMessage[]) => CompactInputMessage[],
+): CompactInputMessage[] {
+  const deltaMessages = messages.slice(cache.messageCount);
+  return [buildCachedCompactInput(cache), ...messagesToCompactInput(deltaMessages)];
+}

--- a/compact-cache.ts
+++ b/compact-cache.ts
@@ -1,16 +1,7 @@
-import type { CompactResult } from "@morphllm/morphsdk";
-
 export type CompactInputMessage = {
   role: string;
   content: string;
   name?: string;
-};
-
-type CacheableMessage = {
-  info: {
-    sessionID: string;
-    id: string;
-  };
 };
 
 export type ChunkSummary = {

--- a/compact-cache.ts
+++ b/compact-cache.ts
@@ -19,10 +19,18 @@ type ResultWithOutput = {
 
 export type SessionCompactCache<TResult = CompactResult> = {
   sessionID: string;
-  firstMessageId: string;
-  lastMessageId: string;
   messageCount: number;
+  messageDigests: string[];
+  prefixDigest: string;
+  configDigest: string;
   result: TResult;
+  incrementalCount: number;
+};
+
+export type CompactFingerprint = {
+  messageDigests: string[];
+  prefixDigest: string;
+  configDigest: string;
 };
 
 export function createBoundedCompactCache<TResult>(maxSize: number) {
@@ -63,51 +71,65 @@ export function buildCompactCacheEntry<
 >(
   messages: TMessage[],
   result: TResult,
+  fingerprint: CompactFingerprint,
+  incrementalCount: number = 0,
 ): SessionCompactCache<TResult> {
   return {
     sessionID: messages[0]!.info.sessionID,
-    firstMessageId: messages[0]!.info.id,
-    lastMessageId: messages[messages.length - 1]!.info.id,
     messageCount: messages.length,
+    messageDigests: fingerprint.messageDigests,
+    prefixDigest: fingerprint.prefixDigest,
+    configDigest: fingerprint.configDigest,
     result,
+    incrementalCount,
   };
 }
 
-export function canReuseCompactCache<TMessage extends CacheableMessage, TResult>(
+export function canReuseCompactCache<TResult>(
   cache: SessionCompactCache<TResult>,
-  messages: TMessage[],
+  sessionID: string,
+  fingerprint: CompactFingerprint,
 ): boolean {
   return (
-    cache.sessionID === messages[0]!.info.sessionID &&
-    cache.messageCount === messages.length &&
-    cache.firstMessageId === messages[0]!.info.id &&
-    cache.lastMessageId === messages[messages.length - 1]!.info.id
+    cache.sessionID === sessionID &&
+    cache.messageCount === fingerprint.messageDigests.length &&
+    cache.configDigest === fingerprint.configDigest &&
+    cache.prefixDigest === fingerprint.prefixDigest
   );
 }
 
-export function canExtendCompactCache<
-  TMessage extends CacheableMessage,
-  TResult,
->(
+export function canExtendCompactCache<TResult>(
   cache: SessionCompactCache<TResult>,
-  messages: TMessage[],
+  sessionID: string,
+  fingerprint: CompactFingerprint,
+  maxIncrementalExtensions: number = 10,
 ): boolean {
   if (
-    cache.sessionID !== messages[0]!.info.sessionID ||
-    cache.messageCount >= messages.length ||
-    cache.firstMessageId !== messages[0]!.info.id
+    cache.sessionID !== sessionID ||
+    cache.configDigest !== fingerprint.configDigest ||
+    cache.messageCount >= fingerprint.messageDigests.length
   ) {
     return false;
   }
 
-  return messages[cache.messageCount - 1]?.info.id === cache.lastMessageId;
+  if (cache.incrementalCount >= maxIncrementalExtensions) {
+    return false;
+  }
+
+  if (cache.messageDigests.length !== cache.messageCount) {
+    return false;
+  }
+
+  return cache.messageDigests.every(
+    (digest, index) => fingerprint.messageDigests[index] === digest,
+  );
 }
 
 export function buildCachedCompactInput<TResult extends ResultWithOutput>(
   cache: SessionCompactCache<TResult>,
 ): CompactInputMessage {
   return {
-    role: "user",
+    role: "assistant",
     content: `[Morph Compact summary of ${cache.messageCount} earlier messages]\n\n${cache.result.output}`,
   };
 }

--- a/compact-cache.ts
+++ b/compact-cache.ts
@@ -13,31 +13,30 @@ type CacheableMessage = {
   };
 };
 
-type ResultWithOutput = {
-  output: string;
-};
-
-export type SessionCompactCache<TResult = CompactResult> = {
-  sessionID: string;
+export type ChunkSummary = {
   messageCount: number;
   messageDigests: string[];
-  prefixDigest: string;
+  output: string;
+  charCountSaved: number;
+};
+
+export type SessionCompactCache = {
+  sessionID: string;
   configDigest: string;
-  result: TResult;
-  incrementalCount: number;
+  chunks: ChunkSummary[];
+  totalMessagesCompacted: number;
 };
 
 export type CompactFingerprint = {
   messageDigests: string[];
-  prefixDigest: string;
   configDigest: string;
 };
 
-export function createBoundedCompactCache<TResult>(maxSize: number) {
-  const map = new Map<string, SessionCompactCache<TResult>>();
+export function createBoundedCompactCache(maxSize: number) {
+  const map = new Map<string, SessionCompactCache>();
 
   return {
-    get(sessionID: string): SessionCompactCache<TResult> | undefined {
+    get(sessionID: string): SessionCompactCache | undefined {
       const entry = map.get(sessionID);
       if (entry) {
         map.delete(sessionID);
@@ -46,7 +45,7 @@ export function createBoundedCompactCache<TResult>(maxSize: number) {
       return entry;
     },
 
-    set(sessionID: string, entry: SessionCompactCache<TResult>) {
+    set(sessionID: string, entry: SessionCompactCache) {
       map.delete(sessionID);
       map.set(sessionID, entry);
       if (map.size > maxSize) {
@@ -65,83 +64,29 @@ export function createBoundedCompactCache<TResult>(maxSize: number) {
   };
 }
 
-export function buildCompactCacheEntry<
-  TMessage extends CacheableMessage,
-  TResult,
->(
-  messages: TMessage[],
-  result: TResult,
-  fingerprint: CompactFingerprint,
-  incrementalCount: number = 0,
-): SessionCompactCache<TResult> {
-  return {
-    sessionID: messages[0]!.info.sessionID,
-    messageCount: messages.length,
-    messageDigests: fingerprint.messageDigests,
-    prefixDigest: fingerprint.prefixDigest,
-    configDigest: fingerprint.configDigest,
-    result,
-    incrementalCount,
-  };
-}
+export function matchCacheChunks(
+  cache: SessionCompactCache,
+  messageDigests: string[]
+): {
+  matchedChunks: ChunkSummary[];
+  matchedMessageCount: number;
+} {
+  const matchedChunks: ChunkSummary[] = [];
+  let matchedMessageCount = 0;
 
-export function canReuseCompactCache<TResult>(
-  cache: SessionCompactCache<TResult>,
-  sessionID: string,
-  fingerprint: CompactFingerprint,
-): boolean {
-  return (
-    cache.sessionID === sessionID &&
-    cache.messageCount === fingerprint.messageDigests.length &&
-    cache.configDigest === fingerprint.configDigest &&
-    cache.prefixDigest === fingerprint.prefixDigest
-  );
-}
-
-export function canExtendCompactCache<TResult>(
-  cache: SessionCompactCache<TResult>,
-  sessionID: string,
-  fingerprint: CompactFingerprint,
-  maxIncrementalExtensions: number = 10,
-): boolean {
-  if (
-    cache.sessionID !== sessionID ||
-    cache.configDigest !== fingerprint.configDigest ||
-    cache.messageCount >= fingerprint.messageDigests.length
-  ) {
-    return false;
+  for (const chunk of cache.chunks) {
+    let chunkMatches = true;
+    for (let i = 0; i < chunk.messageCount; i++) {
+      if (matchedMessageCount + i >= messageDigests.length ||
+        messageDigests[matchedMessageCount + i] !== chunk.messageDigests[i]) {
+        chunkMatches = false;
+        break;
+      }
+    }
+    if (!chunkMatches) break;
+    matchedChunks.push(chunk);
+    matchedMessageCount += chunk.messageCount;
   }
 
-  if (cache.incrementalCount >= maxIncrementalExtensions) {
-    return false;
-  }
-
-  if (cache.messageDigests.length !== cache.messageCount) {
-    return false;
-  }
-
-  return cache.messageDigests.every(
-    (digest, index) => fingerprint.messageDigests[index] === digest,
-  );
-}
-
-export function buildCachedCompactInput<TResult extends ResultWithOutput>(
-  cache: SessionCompactCache<TResult>,
-): CompactInputMessage {
-  return {
-    role: "assistant",
-    content: `[Morph Compact summary of ${cache.messageCount} earlier messages]\n\n${cache.result.output}`,
-  };
-}
-
-export function buildIncrementalCompactInput<
-  TMessage extends CacheableMessage,
-  TResult extends ResultWithOutput,
->(
-  cache: SessionCompactCache<TResult>,
-  messages: TMessage[],
-  messagesToCompactInput: (messages: TMessage[]) => CompactInputMessage[],
-): CompactInputMessage[] {
-  const deltaMessages = messages.slice(cache.messageCount);
-  return [buildCachedCompactInput(cache), ...messagesToCompactInput(deltaMessages)];
+  return { matchedChunks, matchedMessageCount };
 }

--- a/compact-cache.ts
+++ b/compact-cache.ts
@@ -66,19 +66,25 @@ export function createBoundedCompactCache(maxSize: number) {
 
 export function matchCacheChunks(
   cache: SessionCompactCache,
-  messageDigests: string[]
+  fingerprint: CompactFingerprint,
 ): {
   matchedChunks: ChunkSummary[];
   matchedMessageCount: number;
 } {
+  if (cache.configDigest !== fingerprint.configDigest) {
+    return { matchedChunks: [], matchedMessageCount: 0 };
+  }
+
   const matchedChunks: ChunkSummary[] = [];
   let matchedMessageCount = 0;
 
   for (const chunk of cache.chunks) {
     let chunkMatches = true;
     for (let i = 0; i < chunk.messageCount; i++) {
-      if (matchedMessageCount + i >= messageDigests.length ||
-        messageDigests[matchedMessageCount + i] !== chunk.messageDigests[i]) {
+      if (
+        matchedMessageCount + i >= fingerprint.messageDigests.length ||
+        fingerprint.messageDigests[matchedMessageCount + i] !== chunk.messageDigests[i]
+      ) {
         chunkMatches = false;
         break;
       }

--- a/index.test.ts
+++ b/index.test.ts
@@ -381,7 +381,7 @@ function serializePart(part: FakePart): string {
       return `[Tool: ${part.tool}] ${state.status}`;
     }
     case "reasoning":
-      return `[Reasoning] ${part.text}`;
+      return "";
     default:
       return `[${part.type}]`;
   }
@@ -393,9 +393,28 @@ function messagesToCompactInput(
   return messages
     .map((m) => ({
       role: m.info.role,
-      content: m.parts.map(serializePart).join("\n"),
+      content: m.parts.map(serializePart).filter(Boolean).join("\n"),
     }))
     .filter((m) => m.content.length > 0);
+}
+
+function buildFakeFingerprint(
+  messages: FakeMessage[],
+  configDigest = "cfg-v1",
+) {
+  const messageDigests = messages.map((message) =>
+    JSON.stringify({
+      id: message.info.id,
+      role: message.info.role,
+      content: message.parts.map(serializePart).filter(Boolean),
+    }),
+  );
+
+  return {
+    messageDigests,
+    prefixDigest: messageDigests.join("\x1e"),
+    configDigest,
+  };
 }
 
 function estimateTotalChars(messages: FakeMessage[]): number {
@@ -588,10 +607,10 @@ describe("serializePart", () => {
     expect(result).toBe("[Tool: edit] pending");
   });
 
-  test("serializes reasoning part", () => {
+  test("omits reasoning part from compaction input", () => {
     expect(
       serializePart({ type: "reasoning", text: "thinking about this..." }),
-    ).toBe("[Reasoning] thinking about this...");
+    ).toBe("");
   });
 
   test("serializes unknown part type as bracket marker", () => {
@@ -674,6 +693,14 @@ describe("messagesToCompactInput", () => {
     expect(result[0]!.content).toContain("[Tool: read]");
     expect(result[0]!.content).toContain("Done");
   });
+
+  test("omits reasoning-only content entirely", () => {
+    const msg: FakeMessage = {
+      info: { id: "1", role: "assistant", sessionID: "s" },
+      parts: [{ type: "reasoning", text: "private chain of thought" }],
+    };
+    expect(messagesToCompactInput([msg])).toEqual([]);
+  });
 });
 
 describe("estimateTotalChars", () => {
@@ -735,11 +762,21 @@ describe("incremental compaction cache helpers", () => {
       makeTextMsg("1", "user", "hello"),
       makeTextMsg("2", "assistant", "hi"),
     ];
-    const cache = buildCompactCacheEntry(older, makeCompactResult("summary"));
+    const sessionID = older[0]!.info.sessionID;
+    const fingerprint = buildFakeFingerprint(older);
+    const cache = buildCompactCacheEntry(
+      older,
+      makeCompactResult("summary"),
+      fingerprint,
+    );
 
-    expect(canReuseCompactCache(cache, older)).toBe(true);
+    expect(canReuseCompactCache(cache, sessionID, fingerprint)).toBe(true);
     expect(
-      canReuseCompactCache(cache, [...older, makeTextMsg("3", "user", "next")]),
+      canReuseCompactCache(
+        cache,
+        sessionID,
+        buildFakeFingerprint([...older, makeTextMsg("3", "user", "next")]),
+      ),
     ).toBe(false);
   });
 
@@ -748,15 +785,22 @@ describe("incremental compaction cache helpers", () => {
       makeTextMsg("1", "user", "hello"),
       makeTextMsg("2", "assistant", "hi"),
     ];
-    const cache = buildCompactCacheEntry(older, makeCompactResult("summary"));
+    const sessionID = older[0]!.info.sessionID;
+    const cache = buildCompactCacheEntry(
+      older,
+      makeCompactResult("summary"),
+      buildFakeFingerprint(older),
+    );
     const extended = [...older, makeTextMsg("3", "user", "next step")];
 
-    expect(canExtendCompactCache(cache, extended)).toBe(true);
+    expect(
+      canExtendCompactCache(cache, sessionID, buildFakeFingerprint(extended)),
+    ).toBe(true);
     expect(
       buildIncrementalCompactInput(cache, extended, messagesToCompactInput),
     ).toEqual([
       {
-        role: "user",
+        role: "assistant",
         content: "[Morph Compact summary of 2 earlier messages]\n\nsummary",
       },
       { role: "user", content: "next step" },
@@ -768,14 +812,76 @@ describe("incremental compaction cache helpers", () => {
       makeTextMsg("1", "user", "hello"),
       makeTextMsg("2", "assistant", "hi"),
     ];
-    const cache = buildCompactCacheEntry(older, makeCompactResult("summary"));
+    const sessionID = older[0]!.info.sessionID;
+    const cache = buildCompactCacheEntry(
+      older,
+      makeCompactResult("summary"),
+      buildFakeFingerprint(older),
+    );
     const differentPrefix = [
       makeTextMsg("x", "user", "different"),
       makeTextMsg("2", "assistant", "hi"),
       makeTextMsg("3", "user", "next"),
     ];
 
-    expect(canExtendCompactCache(cache, differentPrefix)).toBe(false);
+    expect(
+      canExtendCompactCache(
+        cache,
+        sessionID,
+        buildFakeFingerprint(differentPrefix),
+      ),
+    ).toBe(false);
+  });
+
+  test("does not reuse cache when middle message content changes but ids stay stable", () => {
+    const older = [
+      makeTextMsg("1", "user", "hello"),
+      makeTextMsg("2", "assistant", "hi"),
+      makeTextMsg("3", "user", "next"),
+    ];
+    const sessionID = older[0]!.info.sessionID;
+    const cache = buildCompactCacheEntry(
+      older,
+      makeCompactResult("summary"),
+      buildFakeFingerprint(older),
+    );
+    const editedMiddle = [
+      older[0]!,
+      {
+        ...older[1]!,
+        parts: [{ type: "text", text: "changed answer" }] as FakePart[],
+      },
+      older[2]!,
+    ];
+
+    expect(
+      canReuseCompactCache(
+        cache,
+        sessionID,
+        buildFakeFingerprint(editedMiddle),
+      ),
+    ).toBe(false);
+  });
+
+  test("does not reuse cache when compaction config changes", () => {
+    const older = [
+      makeTextMsg("1", "user", "hello"),
+      makeTextMsg("2", "assistant", "hi"),
+    ];
+    const sessionID = older[0]!.info.sessionID;
+    const cache = buildCompactCacheEntry(
+      older,
+      makeCompactResult("summary"),
+      buildFakeFingerprint(older, "cfg-v1"),
+    );
+
+    expect(
+      canReuseCompactCache(
+        cache,
+        sessionID,
+        buildFakeFingerprint(older, "cfg-v2"),
+      ),
+    ).toBe(false);
   });
 });
 
@@ -783,7 +889,11 @@ describe("bounded LRU compact cache", () => {
   function entryForSession(sid: string) {
     const msgs = [makeTextMsg("1", "user", "hi")];
     msgs[0]!.info.sessionID = sid;
-    return buildCompactCacheEntry(msgs, makeCompactResult(`summary-${sid}`));
+    return buildCompactCacheEntry(
+      msgs,
+      makeCompactResult(`summary-${sid}`),
+      buildFakeFingerprint(msgs, `cfg-${sid}`),
+    );
   }
 
   test("evicts least-recently-used entry when cap is exceeded", () => {
@@ -933,12 +1043,19 @@ describe("compaction integration", () => {
     expect(compactInput.every((m) => m.content.length > 0)).toBe(true);
 
     // Incremental cache reuses exact prefixes and can extend appended ones
-    const cache = buildCompactCacheEntry(older, makeCompactResult("summary"));
-    expect(canReuseCompactCache(cache, older)).toBe(true);
+    const cache = buildCompactCacheEntry(
+      older,
+      makeCompactResult("summary"),
+      buildFakeFingerprint(older),
+    );
+    expect(
+      canReuseCompactCache(cache, older[0]!.info.sessionID, buildFakeFingerprint(older)),
+    ).toBe(true);
     expect(
       canExtendCompactCache(
         cache,
-        [...older, makeTextMsg("new-id", "user", "different")],
+        older[0]!.info.sessionID,
+        buildFakeFingerprint([...older, makeTextMsg("new-id", "user", "different")]),
       ),
     ).toBe(true);
   });
@@ -1019,6 +1136,10 @@ describe("compaction integration", () => {
             { role: "user", content: "A".repeat(100) },
             { role: "assistant", content: "B".repeat(100) },
           ]);
+          expect(firstOutput.messages[0]!.info.role).toBe("assistant");
+          expect(firstOutput.messages[0]!.parts[0]!.text).toContain(
+            "[Background context summary of 2 earlier messages.]",
+          );
 
           const secondOutput = { messages: structuredClone(baseMessages) };
           await transform({}, secondOutput);
@@ -1037,7 +1158,7 @@ describe("compaction integration", () => {
           expect(requests).toHaveLength(2);
           expect(requests[1]!.body.messages).toEqual([
             {
-              role: "user",
+              role: "assistant",
               content: "[Morph Compact summary of 2 earlier messages]\n\nsummary-1",
             },
             { role: "user", content: "C".repeat(100) },
@@ -1045,7 +1166,9 @@ describe("compaction integration", () => {
           expect(
             logs.some((entry) => entry.message.includes("Compact (incremental)")),
           ).toBe(true);
-          expect(toasts).toHaveLength(1);
+          expect(toasts).toHaveLength(2);
+          expect(toasts[1]!.variant).toBe("success");
+          expect(toasts[1]!.message).toContain("Context updated in");
         },
       );
     } finally {

--- a/index.test.ts
+++ b/index.test.ts
@@ -386,6 +386,27 @@ function serializePart(part: FakePart): string {
   }
 }
 
+function serializePartForFingerprint(part: FakePart): string {
+  switch (part.type) {
+    case "text":
+      return part.text;
+    case "tool": {
+      const state = part.state;
+      if (state.status === "completed") {
+        return `[Tool: ${part.tool}] ${JSON.stringify(state.input)}\nOutput: ${state.output || ""}`;
+      }
+      if (state.status === "error") {
+        return `[Tool: ${part.tool}] Error: ${state.error}`;
+      }
+      return `[Tool: ${part.tool}] ${state.status}`;
+    }
+    case "reasoning":
+      return "";
+    default:
+      return `[${part.type}]`;
+  }
+}
+
 function messagesToCompactInput(
   messages: FakeMessage[],
 ): { role: string; content: string }[] {
@@ -405,7 +426,7 @@ function buildFakeFingerprint(
     JSON.stringify({
       id: message.info.id,
       role: message.info.role,
-      content: message.parts.map(serializePart).filter(Boolean),
+      content: message.parts.map(serializePartForFingerprint).filter(Boolean),
     }),
   );
 
@@ -506,11 +527,11 @@ function makeTextMsg(
   const info =
     role === "assistant"
       ? {
-          id,
-          role,
-          sessionID: "sess-1",
-          time: { created: 1, completed: 2 },
-        }
+        id,
+        role,
+        sessionID: "sess-1",
+        time: { created: 1, completed: 2 },
+      }
       : { id, role, sessionID: "sess-1" };
 
   return {
@@ -532,16 +553,16 @@ function makeToolMsg(
       ? { status: "completed", input: state.input, output: state.output }
       : state.status === "running"
         ? {
-            status: "running",
-            input: state.input ?? {},
-            title: state.title,
-            time: { start: 1 },
-          }
+          status: "running",
+          input: state.input ?? {},
+          title: state.title,
+          time: { start: 1 },
+        }
         : {
-            status: "pending",
-            input: state.input ?? {},
-            raw: state.raw ?? "",
-          };
+          status: "pending",
+          input: state.input ?? {},
+          raw: state.raw ?? "",
+        };
 
   return {
     info: {
@@ -569,6 +590,7 @@ const COMPACT_ENV_KEYS = [
   "MORPH_COMPACT_CHAR_THRESHOLD",
   "MORPH_COMPACT_PRESERVE_RECENT",
   "MORPH_COMPACT_CHUNK_SIZE",
+  "MORPH_COMPACT_MIN_UNCACHED_CHARS",
 ] as const;
 
 async function withCompactEnv<T>(
@@ -806,6 +828,25 @@ describe("chunk cache helpers", () => {
       matchedChunks: cache.chunks,
       matchedMessageCount: 4,
     });
+  });
+
+  test("full fingerprinting distinguishes long tool outputs with the same truncated prefix", () => {
+    const sharedPrefix = "x".repeat(2000);
+    const first = makeToolMsg("1", "read", {
+      status: "completed",
+      input: { path: "/tmp/file-a.ts" },
+      output: `${sharedPrefix}-alpha`,
+    });
+    const second = makeToolMsg("1", "read", {
+      status: "completed",
+      input: { path: "/tmp/file-a.ts" },
+      output: `${sharedPrefix}-beta`,
+    });
+
+    expect(serializePart(first.parts[0]!)).toBe(serializePart(second.parts[0]!));
+    expect(buildFakeFingerprint([first]).messageDigests[0]).not.toBe(
+      buildFakeFingerprint([second]).messageDigests[0],
+    );
   });
 
   test("matches only the cached prefix when the transcript extends beyond it", () => {
@@ -1086,6 +1127,7 @@ describe("compaction integration", () => {
           MORPH_COMPACT_CHAR_THRESHOLD: "1",
           MORPH_COMPACT_PRESERVE_RECENT: "1",
           MORPH_COMPACT_CHUNK_SIZE: "2",
+          MORPH_COMPACT_MIN_UNCACHED_CHARS: "1",
         },
         async () => {
           const mod = await import(
@@ -1201,7 +1243,7 @@ describe("compaction integration", () => {
           const hooks = await plugin({
             directory: import.meta.dir,
             client: {
-              app: { log: async () => {} },
+              app: { log: async () => { } },
               tui: {
                 showToast: async ({ body }: any) => {
                   toasts.push(body);
@@ -1258,6 +1300,7 @@ describe("compaction integration", () => {
           MORPH_COMPACT_CHAR_THRESHOLD: "1",
           MORPH_COMPACT_PRESERVE_RECENT: "1",
           MORPH_COMPACT_CHUNK_SIZE: "2",
+          MORPH_COMPACT_MIN_UNCACHED_CHARS: "1",
         },
         async () => {
           const mod = await import(
@@ -1267,7 +1310,7 @@ describe("compaction integration", () => {
           const hooks = await plugin({
             directory: import.meta.dir,
             client: {
-              app: { log: async () => {} },
+              app: { log: async () => { } },
             },
           });
 
@@ -1298,7 +1341,7 @@ describe("compaction integration", () => {
     }
   });
 
-  test("plugin hook keeps compaction cache isolated per session", async () => {
+  test("plugin hook does not cache unstable history in the middle of the compactable prefix", async () => {
     const originalFetch = globalThis.fetch;
     const requests: Array<{ url: string; body: any }> = [];
 
@@ -1321,61 +1364,102 @@ describe("compaction integration", () => {
           MORPH_COMPACT_CHAR_THRESHOLD: "1",
           MORPH_COMPACT_PRESERVE_RECENT: "1",
           MORPH_COMPACT_CHUNK_SIZE: "2",
+          MORPH_COMPACT_MIN_UNCACHED_CHARS: "1",
         },
         async () => {
           const mod = await import(
-            `./index.ts?compaction-session-test=${Date.now()}-${Math.random()}`
+            `./index.ts?compaction-unstable-middle-test=${Date.now()}-${Math.random()}`
           );
           const plugin = mod.default;
           const hooks = await plugin({
             directory: import.meta.dir,
             client: {
-              app: { log: async () => {} },
+              app: { log: async () => { } },
             },
           });
 
           const transform = hooks["experimental.chat.messages.transform"];
-          const sessionOne = [
-            {
-              ...makeTextMsg("1", "user", "A".repeat(100)),
-              info: { id: "1", role: "user" as const, sessionID: "s1" },
-            },
-            {
-              ...makeTextMsg("2", "assistant", "B".repeat(100)),
-              info: { id: "2", role: "assistant" as const, sessionID: "s1" },
-            },
-            {
-              ...makeTextMsg("3", "user", "C".repeat(100)),
-              info: { id: "3", role: "user" as const, sessionID: "s1" },
-            },
-          ];
-          const sessionTwo = [
-            {
-              ...makeTextMsg("1", "user", "A".repeat(100)),
-              info: { id: "1", role: "user" as const, sessionID: "s2" },
-            },
-            {
-              ...makeTextMsg("2", "assistant", "B".repeat(100)),
-              info: { id: "2", role: "assistant" as const, sessionID: "s2" },
-            },
-            {
-              ...makeTextMsg("3", "user", "C".repeat(100)),
-              info: { id: "3", role: "user" as const, sessionID: "s2" },
-            },
+          const transcript = [
+            makeTextMsg("1", "user", "A".repeat(100)),
+            makeToolMsg("2", "read", {
+              status: "pending",
+              input: { path: "/tmp/file.ts" },
+              raw: "{\"path\":\"/tmp/file.ts\"}",
+            }),
+            makeTextMsg("3", "assistant", "C".repeat(100)),
+            makeTextMsg("4", "user", "D".repeat(100)),
           ];
 
-          await transform({}, { messages: structuredClone(sessionOne) });
-          await transform({}, { messages: structuredClone(sessionTwo) });
-
-          expect(requests).toHaveLength(2);
+          const firstOutput = { messages: structuredClone(transcript) };
+          await transform({}, firstOutput);
+          expect(requests).toHaveLength(1);
           expect(requests[0]!.body.messages).toEqual([
             { role: "user", content: "A".repeat(100) },
-            { role: "assistant", content: "B".repeat(100) },
           ]);
-          expect(requests[1]!.body.messages).toEqual([
-            { role: "user", content: "A".repeat(100) },
-            { role: "assistant", content: "B".repeat(100) },
+          expect(firstOutput.messages[1]!.parts[0]!.type).toBe("tool");
+          expect(firstOutput.messages[2]!.parts[0]!.type).toBe("text");
+
+          const secondOutput = { messages: structuredClone(transcript) };
+          await transform({}, secondOutput);
+          expect(requests).toHaveLength(1);
+        },
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("plugin hook serializes same-session compaction work", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; body: any }> = [];
+
+    globalThis.fetch = async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const body = init?.body ? JSON.parse(String(init.body)) : null;
+      requests.push({ url, body });
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      return new Response(JSON.stringify(makeCompactResult("summary-1")), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    try {
+      await withCompactEnv(
+        {
+          MORPH_API_KEY: "sk-test-key",
+          MORPH_COMPACT: "true",
+          MORPH_COMPACT_CHAR_THRESHOLD: "1",
+          MORPH_COMPACT_PRESERVE_RECENT: "1",
+          MORPH_COMPACT_CHUNK_SIZE: "2",
+          MORPH_COMPACT_MIN_UNCACHED_CHARS: "1",
+        },
+        async () => {
+          const mod = await import(
+            `./index.ts?compaction-lock-test=${Date.now()}-${Math.random()}`
+          );
+          const plugin = mod.default;
+          const hooks = await plugin({
+            directory: import.meta.dir,
+            client: {
+              app: { log: async () => { } },
+            },
+          });
+
+          const transform = hooks["experimental.chat.messages.transform"];
+          const transcript = [
+            makeTextMsg("1", "user", "A".repeat(100)),
+            makeTextMsg("2", "assistant", "B".repeat(100)),
+            makeTextMsg("3", "user", "C".repeat(100)),
+          ];
+
+          await Promise.all([
+            transform({}, { messages: structuredClone(transcript) }),
+            transform({}, { messages: structuredClone(transcript) }),
           ]);
+
+          expect(requests).toHaveLength(1);
         },
       );
     } finally {

--- a/index.test.ts
+++ b/index.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { CompactClient } from "@morphllm/morphsdk";
+import {
+  buildCompactCacheEntry,
+  buildIncrementalCompactInput,
+  canExtendCompactCache,
+  canReuseCompactCache,
+  createBoundedCompactCache,
+} from "./compact-cache";
 
 // These are internal to the plugin but duplicated here for testing.
 const EXISTING_CODE_MARKER = "// ... existing code ...";
@@ -402,9 +409,44 @@ function estimateTotalChars(messages: FakeMessage[]): number {
   return total;
 }
 
-function hashMessageIds(messages: { info: { id: string } }[]): string {
-  return messages.map((m) => m.info.id).join("|");
+type FakeCompactResult = {
+  id: string;
+  output: string;
+  messages: Array<{
+    role: string;
+    content: string;
+    compacted_line_ranges: Array<{ start: number; end: number }>;
+  }>;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    compression_ratio: number;
+    processing_time_ms: number;
+  };
+  model: string;
+};
+
+function makeCompactResult(output: string): FakeCompactResult {
+  return {
+    id: `compact-${output}`,
+    output,
+    messages: [
+      {
+        role: "user",
+        content: output,
+        compacted_line_ranges: [],
+      },
+    ],
+    usage: {
+      input_tokens: 100,
+      output_tokens: 25,
+      compression_ratio: 0.25,
+      processing_time_ms: 5,
+    },
+    model: "morph-compactor",
+  };
 }
+
 
 // Helpers to build fake messages for tests
 function makeTextMsg(
@@ -611,29 +653,123 @@ describe("estimateTotalChars", () => {
   });
 });
 
-describe("hashMessageIds", () => {
-  test("joins message IDs with pipe", () => {
-    const messages = [
-      { info: { id: "abc" } },
-      { info: { id: "def" } },
-      { info: { id: "ghi" } },
+describe("incremental compaction cache helpers", () => {
+  test("reuses cache only for the exact same older prefix", () => {
+    const older = [
+      makeTextMsg("1", "user", "hello"),
+      makeTextMsg("2", "assistant", "hi"),
     ];
-    expect(hashMessageIds(messages)).toBe("abc|def|ghi");
+    const cache = buildCompactCacheEntry(older, makeCompactResult("summary"));
+
+    expect(canReuseCompactCache(cache, older)).toBe(true);
+    expect(
+      canReuseCompactCache(cache, [...older, makeTextMsg("3", "user", "next")]),
+    ).toBe(false);
   });
 
-  test("returns empty string for empty array", () => {
-    expect(hashMessageIds([])).toBe("");
+  test("extends cache when the older prefix grows by appending messages", () => {
+    const older = [
+      makeTextMsg("1", "user", "hello"),
+      makeTextMsg("2", "assistant", "hi"),
+    ];
+    const cache = buildCompactCacheEntry(older, makeCompactResult("summary"));
+    const extended = [...older, makeTextMsg("3", "user", "next step")];
+
+    expect(canExtendCompactCache(cache, extended)).toBe(true);
+    expect(
+      buildIncrementalCompactInput(cache, extended, messagesToCompactInput),
+    ).toEqual([
+      {
+        role: "user",
+        content: "[Morph Compact summary of 2 earlier messages]\n\nsummary",
+      },
+      { role: "user", content: "next step" },
+    ]);
   });
 
-  test("handles single message", () => {
-    expect(hashMessageIds([{ info: { id: "only" } }])).toBe("only");
+  test("falls back to full compaction when the cached prefix no longer matches", () => {
+    const older = [
+      makeTextMsg("1", "user", "hello"),
+      makeTextMsg("2", "assistant", "hi"),
+    ];
+    const cache = buildCompactCacheEntry(older, makeCompactResult("summary"));
+    const differentPrefix = [
+      makeTextMsg("x", "user", "different"),
+      makeTextMsg("2", "assistant", "hi"),
+      makeTextMsg("3", "user", "next"),
+    ];
+
+    expect(canExtendCompactCache(cache, differentPrefix)).toBe(false);
+  });
+});
+
+describe("bounded LRU compact cache", () => {
+  function entryForSession(sid: string) {
+    const msgs = [makeTextMsg("1", "user", "hi")];
+    msgs[0]!.info.sessionID = sid;
+    return buildCompactCacheEntry(msgs, makeCompactResult(`summary-${sid}`));
+  }
+
+  test("evicts least-recently-used entry when cap is exceeded", () => {
+    const cache = createBoundedCompactCache<FakeCompactResult>(3);
+    cache.set("s1", entryForSession("s1"));
+    cache.set("s2", entryForSession("s2"));
+    cache.set("s3", entryForSession("s3"));
+
+    // All three present
+    expect(cache.size()).toBe(3);
+
+    // Adding a 4th evicts s1 (oldest)
+    cache.set("s4", entryForSession("s4"));
+    expect(cache.size()).toBe(3);
+    expect(cache.get("s1")).toBeUndefined();
+    expect(cache.get("s4")).toBeDefined();
+  });
+
+  test("read refreshes recency so hot sessions survive eviction", () => {
+    const cache = createBoundedCompactCache<FakeCompactResult>(3);
+    cache.set("s1", entryForSession("s1"));
+    cache.set("s2", entryForSession("s2"));
+    cache.set("s3", entryForSession("s3"));
+
+    // Read s1 — moves it to the most-recent position
+    cache.get("s1");
+
+    // Now s2 is the oldest. Adding s4 should evict s2, not s1.
+    cache.set("s4", entryForSession("s4"));
+    expect(cache.get("s1")).toBeDefined();
+    expect(cache.get("s2")).toBeUndefined();
+    expect(cache.get("s3")).toBeDefined();
+    expect(cache.get("s4")).toBeDefined();
+  });
+
+  test("write refreshes recency for existing sessions", () => {
+    const cache = createBoundedCompactCache<FakeCompactResult>(3);
+    cache.set("s1", entryForSession("s1"));
+    cache.set("s2", entryForSession("s2"));
+    cache.set("s3", entryForSession("s3"));
+
+    // Re-write s1 — moves it to the most-recent position
+    cache.set("s1", entryForSession("s1"));
+
+    // s2 is now oldest
+    cache.set("s4", entryForSession("s4"));
+    expect(cache.get("s1")).toBeDefined();
+    expect(cache.get("s2")).toBeUndefined();
   });
 });
 
 describe("compaction integration", () => {
   const MORPH_API_KEY = process.env.MORPH_API_KEY;
+  const RUN_LIVE_COMPACT_TESTS =
+    process.env.MORPH_RUN_LIVE_COMPACT_TESTS === "true";
 
   test("CompactClient.compact() returns valid result", async () => {
+    if (!RUN_LIVE_COMPACT_TESTS) {
+      console.log("Skipping: MORPH_RUN_LIVE_COMPACT_TESTS not enabled");
+      return;
+    }
+
     if (!MORPH_API_KEY) {
       console.log("Skipping: MORPH_API_KEY not set");
       return;
@@ -720,17 +856,15 @@ describe("compaction integration", () => {
     expect(compactInput.length).toBe(14);
     expect(compactInput.every((m) => m.content.length > 0)).toBe(true);
 
-    // Hash is stable
-    const hash1 = hashMessageIds(older);
-    const hash2 = hashMessageIds(older);
-    expect(hash1).toBe(hash2);
-
-    // Hash changes when messages change
-    const differentOlder = [
-      ...older.slice(0, -1),
-      makeTextMsg("new-id", "user", "different"),
-    ];
-    expect(hashMessageIds(differentOlder)).not.toBe(hash1);
+    // Incremental cache reuses exact prefixes and can extend appended ones
+    const cache = buildCompactCacheEntry(older, makeCompactResult("summary"));
+    expect(canReuseCompactCache(cache, older)).toBe(true);
+    expect(
+      canExtendCompactCache(
+        cache,
+        [...older, makeTextMsg("new-id", "user", "different")],
+      ),
+    ).toBe(true);
   });
 
   test("too few messages does not trigger compaction", () => {
@@ -745,6 +879,234 @@ describe("compaction integration", () => {
     );
     // Even though chars are high, message count is below threshold
     expect(messages.length).toBeLessThan(PRESERVE_RECENT + 2);
+  });
+
+  test("plugin hook reuses exact transcript and incrementally extends older prefixes", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; body: any }> = [];
+
+    globalThis.fetch = async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const body = init?.body ? JSON.parse(String(init.body)) : null;
+      requests.push({ url, body });
+
+      return new Response(JSON.stringify(makeCompactResult(`summary-${requests.length}`)), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const originalEnv = {
+      MORPH_API_KEY: process.env.MORPH_API_KEY,
+      MORPH_COMPACT: process.env.MORPH_COMPACT,
+      MORPH_COMPACT_CHAR_THRESHOLD: process.env.MORPH_COMPACT_CHAR_THRESHOLD,
+      MORPH_COMPACT_PRESERVE_RECENT:
+        process.env.MORPH_COMPACT_PRESERVE_RECENT,
+    };
+
+    process.env.MORPH_API_KEY = "sk-test-key";
+    process.env.MORPH_COMPACT = "true";
+    process.env.MORPH_COMPACT_CHAR_THRESHOLD = "1";
+    process.env.MORPH_COMPACT_PRESERVE_RECENT = "1";
+
+    try {
+      const mod = await import(
+        `./index.ts?compaction-hook-test=${Date.now()}-${Math.random()}`
+      );
+      const plugin = mod.default;
+      const logs: any[] = [];
+      const hooks = await plugin({
+        directory: import.meta.dir,
+        client: {
+          app: {
+            log: async ({ body }: any) => {
+              logs.push(body);
+            },
+          },
+        },
+      });
+
+      const transform = hooks["experimental.chat.messages.transform"];
+      expect(typeof transform).toBe("function");
+
+      const baseMessages = [
+        makeTextMsg("1", "user", "A".repeat(100)),
+        makeTextMsg("2", "assistant", "B".repeat(100)),
+        makeTextMsg("3", "user", "C".repeat(100)),
+      ];
+
+      const firstOutput = { messages: structuredClone(baseMessages) };
+      await transform({}, firstOutput);
+      expect(requests).toHaveLength(1);
+      expect(requests[0]!.body.messages).toEqual([
+        { role: "user", content: "A".repeat(100) },
+        { role: "assistant", content: "B".repeat(100) },
+      ]);
+
+      const secondOutput = { messages: structuredClone(baseMessages) };
+      await transform({}, secondOutput);
+      expect(requests).toHaveLength(1);
+
+      const extendedMessages = [
+        ...baseMessages,
+        makeTextMsg("4", "assistant", "D".repeat(100)),
+      ];
+      const thirdOutput = { messages: structuredClone(extendedMessages) };
+      await transform({}, thirdOutput);
+
+      expect(requests).toHaveLength(2);
+      expect(requests[1]!.body.messages).toEqual([
+        {
+          role: "user",
+          content: "[Morph Compact summary of 2 earlier messages]\n\nsummary-1",
+        },
+        { role: "user", content: "C".repeat(100) },
+      ]);
+      expect(
+        logs.some((entry) => entry.message.includes("Compact (incremental)")),
+      ).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+
+      if (originalEnv.MORPH_API_KEY === undefined) {
+        delete process.env.MORPH_API_KEY;
+      } else {
+        process.env.MORPH_API_KEY = originalEnv.MORPH_API_KEY;
+      }
+
+      if (originalEnv.MORPH_COMPACT === undefined) {
+        delete process.env.MORPH_COMPACT;
+      } else {
+        process.env.MORPH_COMPACT = originalEnv.MORPH_COMPACT;
+      }
+
+      if (originalEnv.MORPH_COMPACT_CHAR_THRESHOLD === undefined) {
+        delete process.env.MORPH_COMPACT_CHAR_THRESHOLD;
+      } else {
+        process.env.MORPH_COMPACT_CHAR_THRESHOLD =
+          originalEnv.MORPH_COMPACT_CHAR_THRESHOLD;
+      }
+
+      if (originalEnv.MORPH_COMPACT_PRESERVE_RECENT === undefined) {
+        delete process.env.MORPH_COMPACT_PRESERVE_RECENT;
+      } else {
+        process.env.MORPH_COMPACT_PRESERVE_RECENT =
+          originalEnv.MORPH_COMPACT_PRESERVE_RECENT;
+      }
+    }
+  });
+
+  test("plugin hook keeps compaction cache isolated per session", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; body: any }> = [];
+
+    globalThis.fetch = async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const body = init?.body ? JSON.parse(String(init.body)) : null;
+      requests.push({ url, body });
+
+      return new Response(JSON.stringify(makeCompactResult(`summary-${requests.length}`)), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const originalEnv = {
+      MORPH_API_KEY: process.env.MORPH_API_KEY,
+      MORPH_COMPACT: process.env.MORPH_COMPACT,
+      MORPH_COMPACT_CHAR_THRESHOLD: process.env.MORPH_COMPACT_CHAR_THRESHOLD,
+      MORPH_COMPACT_PRESERVE_RECENT:
+        process.env.MORPH_COMPACT_PRESERVE_RECENT,
+    };
+
+    process.env.MORPH_API_KEY = "sk-test-key";
+    process.env.MORPH_COMPACT = "true";
+    process.env.MORPH_COMPACT_CHAR_THRESHOLD = "1";
+    process.env.MORPH_COMPACT_PRESERVE_RECENT = "1";
+
+    try {
+      const mod = await import(
+        `./index.ts?compaction-session-test=${Date.now()}-${Math.random()}`
+      );
+      const plugin = mod.default;
+      const hooks = await plugin({
+        directory: import.meta.dir,
+        client: {
+          app: { log: async () => {} },
+        },
+      });
+
+      const transform = hooks["experimental.chat.messages.transform"];
+      const sessionOne = [
+        {
+          ...makeTextMsg("1", "user", "A".repeat(100)),
+          info: { id: "1", role: "user" as const, sessionID: "s1" },
+        },
+        {
+          ...makeTextMsg("2", "assistant", "B".repeat(100)),
+          info: { id: "2", role: "assistant" as const, sessionID: "s1" },
+        },
+        {
+          ...makeTextMsg("3", "user", "C".repeat(100)),
+          info: { id: "3", role: "user" as const, sessionID: "s1" },
+        },
+      ];
+      const sessionTwo = [
+        {
+          ...makeTextMsg("1", "user", "A".repeat(100)),
+          info: { id: "1", role: "user" as const, sessionID: "s2" },
+        },
+        {
+          ...makeTextMsg("2", "assistant", "B".repeat(100)),
+          info: { id: "2", role: "assistant" as const, sessionID: "s2" },
+        },
+        {
+          ...makeTextMsg("3", "user", "C".repeat(100)),
+          info: { id: "3", role: "user" as const, sessionID: "s2" },
+        },
+      ];
+
+      await transform({}, { messages: structuredClone(sessionOne) });
+      await transform({}, { messages: structuredClone(sessionTwo) });
+
+      expect(requests).toHaveLength(2);
+      expect(requests[0]!.body.messages).toEqual([
+        { role: "user", content: "A".repeat(100) },
+        { role: "assistant", content: "B".repeat(100) },
+      ]);
+      expect(requests[1]!.body.messages).toEqual([
+        { role: "user", content: "A".repeat(100) },
+        { role: "assistant", content: "B".repeat(100) },
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+
+      if (originalEnv.MORPH_API_KEY === undefined) {
+        delete process.env.MORPH_API_KEY;
+      } else {
+        process.env.MORPH_API_KEY = originalEnv.MORPH_API_KEY;
+      }
+
+      if (originalEnv.MORPH_COMPACT === undefined) {
+        delete process.env.MORPH_COMPACT;
+      } else {
+        process.env.MORPH_COMPACT = originalEnv.MORPH_COMPACT;
+      }
+
+      if (originalEnv.MORPH_COMPACT_CHAR_THRESHOLD === undefined) {
+        delete process.env.MORPH_COMPACT_CHAR_THRESHOLD;
+      } else {
+        process.env.MORPH_COMPACT_CHAR_THRESHOLD =
+          originalEnv.MORPH_COMPACT_CHAR_THRESHOLD;
+      }
+
+      if (originalEnv.MORPH_COMPACT_PRESERVE_RECENT === undefined) {
+        delete process.env.MORPH_COMPACT_PRESERVE_RECENT;
+      } else {
+        process.env.MORPH_COMPACT_PRESERVE_RECENT =
+          originalEnv.MORPH_COMPACT_PRESERVE_RECENT;
+      }
+    }
   });
 });
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -355,7 +355,12 @@ type FakePart =
   | { type: "file"; filename: string };
 
 type FakeMessage = {
-  info: { id: string; role: "user" | "assistant"; sessionID: string };
+  info: {
+    id: string;
+    role: "user" | "assistant";
+    sessionID: string;
+    time?: { created: number; completed?: number };
+  };
   parts: FakePart[];
 };
 
@@ -454,8 +459,18 @@ function makeTextMsg(
   role: "user" | "assistant",
   text: string,
 ): FakeMessage {
+  const info =
+    role === "assistant"
+      ? {
+          id,
+          role,
+          sessionID: "sess-1",
+          time: { created: 1, completed: 2 },
+        }
+      : { id, role, sessionID: "sess-1" };
+
   return {
-    info: { id, role, sessionID: "sess-1" },
+    info,
     parts: [{ type: "text", text }],
   };
 }
@@ -463,16 +478,42 @@ function makeTextMsg(
 function makeToolMsg(
   id: string,
   toolName: string,
-  input: any,
-  output: string,
+  state:
+    | { status: "completed"; input: any; output: string }
+    | { status: "pending"; input?: any; raw?: string }
+    | { status: "running"; input?: any; title?: string },
 ): FakeMessage {
+  const toolState =
+    state.status === "completed"
+      ? { status: "completed", input: state.input, output: state.output }
+      : state.status === "running"
+        ? {
+            status: "running",
+            input: state.input ?? {},
+            title: state.title,
+            time: { start: 1 },
+          }
+        : {
+            status: "pending",
+            input: state.input ?? {},
+            raw: state.raw ?? "",
+          };
+
   return {
-    info: { id, role: "assistant", sessionID: "sess-1" },
+    info: {
+      id,
+      role: "assistant",
+      sessionID: "sess-1",
+      time:
+        state.status === "completed"
+          ? { created: 1, completed: 2 }
+          : { created: 1 },
+    },
     parts: [
       {
         type: "tool",
         tool: toolName,
-        state: { status: "completed", input, output },
+        state: toolState,
       },
     ],
   };
@@ -616,7 +657,13 @@ describe("estimateTotalChars", () => {
   });
 
   test("counts completed tool input + output", () => {
-    const messages = [makeToolMsg("1", "read", { path: "/a" }, "contents")];
+    const messages = [
+      makeToolMsg("1", "read", {
+        status: "completed",
+        input: { path: "/a" },
+        output: "contents",
+      }),
+    ];
     // JSON.stringify({path:"/a"}) = '{"path":"/a"}' = 13 chars
     // "contents" = 8 chars
     expect(estimateTotalChars(messages)).toBe(13 + 8);
@@ -884,6 +931,7 @@ describe("compaction integration", () => {
   test("plugin hook reuses exact transcript and incrementally extends older prefixes", async () => {
     const originalFetch = globalThis.fetch;
     const requests: Array<{ url: string; body: any }> = [];
+    const toasts: Array<{ title?: string; message: string; variant: string }> = [];
 
     globalThis.fetch = async (input, init) => {
       const url = input instanceof Request ? input.url : String(input);
@@ -923,6 +971,11 @@ describe("compaction integration", () => {
               logs.push(body);
             },
           },
+          tui: {
+            showToast: async ({ body }: any) => {
+              toasts.push(body);
+            },
+          },
         },
       });
 
@@ -946,6 +999,9 @@ describe("compaction integration", () => {
       const secondOutput = { messages: structuredClone(baseMessages) };
       await transform({}, secondOutput);
       expect(requests).toHaveLength(1);
+      expect(toasts).toHaveLength(1);
+      expect(toasts[0]!.variant).toBe("success");
+      expect(toasts[0]!.message).toContain("Context compacted in");
 
       const extendedMessages = [
         ...baseMessages,
@@ -965,6 +1021,191 @@ describe("compaction integration", () => {
       expect(
         logs.some((entry) => entry.message.includes("Compact (incremental)")),
       ).toBe(true);
+      expect(toasts).toHaveLength(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+
+      if (originalEnv.MORPH_API_KEY === undefined) {
+        delete process.env.MORPH_API_KEY;
+      } else {
+        process.env.MORPH_API_KEY = originalEnv.MORPH_API_KEY;
+      }
+
+      if (originalEnv.MORPH_COMPACT === undefined) {
+        delete process.env.MORPH_COMPACT;
+      } else {
+        process.env.MORPH_COMPACT = originalEnv.MORPH_COMPACT;
+      }
+
+      if (originalEnv.MORPH_COMPACT_CHAR_THRESHOLD === undefined) {
+        delete process.env.MORPH_COMPACT_CHAR_THRESHOLD;
+      } else {
+        process.env.MORPH_COMPACT_CHAR_THRESHOLD =
+          originalEnv.MORPH_COMPACT_CHAR_THRESHOLD;
+      }
+
+      if (originalEnv.MORPH_COMPACT_PRESERVE_RECENT === undefined) {
+        delete process.env.MORPH_COMPACT_PRESERVE_RECENT;
+      } else {
+        process.env.MORPH_COMPACT_PRESERVE_RECENT =
+          originalEnv.MORPH_COMPACT_PRESERVE_RECENT;
+      }
+    }
+  });
+
+  test("plugin hook defers compaction while the recent tail has an in-flight tool call", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; body: any }> = [];
+    const toasts: Array<{ title?: string; message: string; variant: string }> =
+      [];
+
+    globalThis.fetch = async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const body = init?.body ? JSON.parse(String(init.body)) : null;
+      requests.push({ url, body });
+
+      return new Response(JSON.stringify(makeCompactResult("summary-1")), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const originalEnv = {
+      MORPH_API_KEY: process.env.MORPH_API_KEY,
+      MORPH_COMPACT: process.env.MORPH_COMPACT,
+      MORPH_COMPACT_CHAR_THRESHOLD: process.env.MORPH_COMPACT_CHAR_THRESHOLD,
+      MORPH_COMPACT_PRESERVE_RECENT:
+        process.env.MORPH_COMPACT_PRESERVE_RECENT,
+    };
+
+    process.env.MORPH_API_KEY = "sk-test-key";
+    process.env.MORPH_COMPACT = "true";
+    process.env.MORPH_COMPACT_CHAR_THRESHOLD = "1";
+    process.env.MORPH_COMPACT_PRESERVE_RECENT = "1";
+
+    try {
+      const mod = await import(
+        `./index.ts?compaction-pending-tool-test=${Date.now()}-${Math.random()}`
+      );
+      const plugin = mod.default;
+      const hooks = await plugin({
+        directory: import.meta.dir,
+        client: {
+          app: { log: async () => {} },
+          tui: {
+            showToast: async ({ body }: any) => {
+              toasts.push(body);
+            },
+          },
+        },
+      });
+
+      const transform = hooks["experimental.chat.messages.transform"];
+      await transform(
+        {},
+        {
+          messages: structuredClone([
+            makeTextMsg("1", "user", "A".repeat(100)),
+            makeTextMsg("2", "assistant", "B".repeat(100)),
+            makeToolMsg("3", "read", {
+              status: "running",
+              input: { path: "/tmp/file.ts" },
+              title: "Reading file",
+            }),
+          ]),
+        },
+      );
+
+      expect(requests).toHaveLength(0);
+      expect(toasts).toHaveLength(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+
+      if (originalEnv.MORPH_API_KEY === undefined) {
+        delete process.env.MORPH_API_KEY;
+      } else {
+        process.env.MORPH_API_KEY = originalEnv.MORPH_API_KEY;
+      }
+
+      if (originalEnv.MORPH_COMPACT === undefined) {
+        delete process.env.MORPH_COMPACT;
+      } else {
+        process.env.MORPH_COMPACT = originalEnv.MORPH_COMPACT;
+      }
+
+      if (originalEnv.MORPH_COMPACT_CHAR_THRESHOLD === undefined) {
+        delete process.env.MORPH_COMPACT_CHAR_THRESHOLD;
+      } else {
+        process.env.MORPH_COMPACT_CHAR_THRESHOLD =
+          originalEnv.MORPH_COMPACT_CHAR_THRESHOLD;
+      }
+
+      if (originalEnv.MORPH_COMPACT_PRESERVE_RECENT === undefined) {
+        delete process.env.MORPH_COMPACT_PRESERVE_RECENT;
+      } else {
+        process.env.MORPH_COMPACT_PRESERVE_RECENT =
+          originalEnv.MORPH_COMPACT_PRESERVE_RECENT;
+      }
+    }
+  });
+
+  test("plugin hook defers compaction when the compaction boundary ends on an in-flight tool call", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; body: any }> = [];
+
+    globalThis.fetch = async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const body = init?.body ? JSON.parse(String(init.body)) : null;
+      requests.push({ url, body });
+
+      return new Response(JSON.stringify(makeCompactResult("summary-1")), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const originalEnv = {
+      MORPH_API_KEY: process.env.MORPH_API_KEY,
+      MORPH_COMPACT: process.env.MORPH_COMPACT,
+      MORPH_COMPACT_CHAR_THRESHOLD: process.env.MORPH_COMPACT_CHAR_THRESHOLD,
+      MORPH_COMPACT_PRESERVE_RECENT:
+        process.env.MORPH_COMPACT_PRESERVE_RECENT,
+    };
+
+    process.env.MORPH_API_KEY = "sk-test-key";
+    process.env.MORPH_COMPACT = "true";
+    process.env.MORPH_COMPACT_CHAR_THRESHOLD = "1";
+    process.env.MORPH_COMPACT_PRESERVE_RECENT = "1";
+
+    try {
+      const mod = await import(
+        `./index.ts?compaction-boundary-tool-test=${Date.now()}-${Math.random()}`
+      );
+      const plugin = mod.default;
+      const hooks = await plugin({
+        directory: import.meta.dir,
+        client: {
+          app: { log: async () => {} },
+        },
+      });
+
+      const transform = hooks["experimental.chat.messages.transform"];
+      await transform(
+        {},
+        {
+          messages: structuredClone([
+            makeTextMsg("1", "user", "A".repeat(100)),
+            makeToolMsg("2", "read", {
+              status: "pending",
+              input: { path: "/tmp/file.ts" },
+              raw: "{\"path\":\"/tmp/file.ts\"}",
+            }),
+            makeTextMsg("3", "user", "C".repeat(100)),
+          ]),
+        },
+      );
+
+      expect(requests).toHaveLength(0);
     } finally {
       globalThis.fetch = originalFetch;
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -3,11 +3,10 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { CompactClient } from "@morphllm/morphsdk";
 import {
-  buildCompactCacheEntry,
-  buildIncrementalCompactInput,
-  canExtendCompactCache,
-  canReuseCompactCache,
   createBoundedCompactCache,
+  matchCacheChunks,
+  type ChunkSummary,
+  type SessionCompactCache,
 } from "./compact-cache";
 
 // These are internal to the plugin but duplicated here for testing.
@@ -412,8 +411,34 @@ function buildFakeFingerprint(
 
   return {
     messageDigests,
-    prefixDigest: messageDigests.join("\x1e"),
     configDigest,
+  };
+}
+
+function makeChunk(
+  messages: FakeMessage[],
+  output: string,
+  charCountSaved = 0,
+): ChunkSummary {
+  const fingerprint = buildFakeFingerprint(messages);
+  return {
+    messageCount: messages.length,
+    messageDigests: fingerprint.messageDigests,
+    output,
+    charCountSaved,
+  };
+}
+
+function makeSessionCache(
+  sessionID: string,
+  chunks: ChunkSummary[],
+  configDigest = "cfg-v1",
+): SessionCompactCache {
+  return {
+    sessionID,
+    configDigest,
+    chunks,
+    totalMessagesCompacted: chunks.reduce((sum, chunk) => sum + chunk.messageCount, 0),
   };
 }
 
@@ -543,6 +568,7 @@ const COMPACT_ENV_KEYS = [
   "MORPH_COMPACT",
   "MORPH_COMPACT_CHAR_THRESHOLD",
   "MORPH_COMPACT_PRESERVE_RECENT",
+  "MORPH_COMPACT_CHUNK_SIZE",
 ] as const;
 
 async function withCompactEnv<T>(
@@ -756,143 +782,113 @@ describe("estimateTotalChars", () => {
   });
 });
 
-describe("incremental compaction cache helpers", () => {
-  test("reuses cache only for the exact same older prefix", () => {
-    const older = [
+describe("chunk cache helpers", () => {
+  test("matches all cached chunks for an identical compacted prefix", () => {
+    const firstChunkMessages = [
       makeTextMsg("1", "user", "hello"),
       makeTextMsg("2", "assistant", "hi"),
     ];
-    const sessionID = older[0]!.info.sessionID;
-    const fingerprint = buildFakeFingerprint(older);
-    const cache = buildCompactCacheEntry(
-      older,
-      makeCompactResult("summary"),
-      fingerprint,
-    );
-
-    expect(canReuseCompactCache(cache, sessionID, fingerprint)).toBe(true);
-    expect(
-      canReuseCompactCache(
-        cache,
-        sessionID,
-        buildFakeFingerprint([...older, makeTextMsg("3", "user", "next")]),
-      ),
-    ).toBe(false);
-  });
-
-  test("extends cache when the older prefix grows by appending messages", () => {
-    const older = [
-      makeTextMsg("1", "user", "hello"),
-      makeTextMsg("2", "assistant", "hi"),
+    const secondChunkMessages = [
+      makeTextMsg("3", "user", "next"),
+      makeTextMsg("4", "assistant", "done"),
     ];
-    const sessionID = older[0]!.info.sessionID;
-    const cache = buildCompactCacheEntry(
-      older,
-      makeCompactResult("summary"),
-      buildFakeFingerprint(older),
-    );
-    const extended = [...older, makeTextMsg("3", "user", "next step")];
-
-    expect(
-      canExtendCompactCache(cache, sessionID, buildFakeFingerprint(extended)),
-    ).toBe(true);
-    expect(
-      buildIncrementalCompactInput(cache, extended, messagesToCompactInput),
-    ).toEqual([
-      {
-        role: "assistant",
-        content: "[Morph Compact summary of 2 earlier messages]\n\nsummary",
-      },
-      { role: "user", content: "next step" },
+    const cache = makeSessionCache("sess-1", [
+      makeChunk(firstChunkMessages, "chunk-1"),
+      makeChunk(secondChunkMessages, "chunk-2"),
     ]);
+
+    expect(
+      matchCacheChunks(
+        cache,
+        buildFakeFingerprint([...firstChunkMessages, ...secondChunkMessages]),
+      ),
+    ).toEqual({
+      matchedChunks: cache.chunks,
+      matchedMessageCount: 4,
+    });
   });
 
-  test("falls back to full compaction when the cached prefix no longer matches", () => {
-    const older = [
+  test("matches only the cached prefix when the transcript extends beyond it", () => {
+    const firstChunkMessages = [
       makeTextMsg("1", "user", "hello"),
       makeTextMsg("2", "assistant", "hi"),
     ];
-    const sessionID = older[0]!.info.sessionID;
-    const cache = buildCompactCacheEntry(
-      older,
-      makeCompactResult("summary"),
-      buildFakeFingerprint(older),
-    );
-    const differentPrefix = [
-      makeTextMsg("x", "user", "different"),
-      makeTextMsg("2", "assistant", "hi"),
+    const secondChunkMessages = [
       makeTextMsg("3", "user", "next"),
+      makeTextMsg("4", "assistant", "done"),
     ];
+    const cache = makeSessionCache("sess-1", [
+      makeChunk(firstChunkMessages, "chunk-1"),
+    ]);
 
     expect(
-      canExtendCompactCache(
+      matchCacheChunks(
         cache,
-        sessionID,
-        buildFakeFingerprint(differentPrefix),
+        buildFakeFingerprint([...firstChunkMessages, ...secondChunkMessages]),
       ),
-    ).toBe(false);
+    ).toEqual({
+      matchedChunks: cache.chunks,
+      matchedMessageCount: 2,
+    });
   });
 
-  test("does not reuse cache when middle message content changes but ids stay stable", () => {
-    const older = [
+  test("stops matching at the first mismatched chunk", () => {
+    const firstChunkMessages = [
       makeTextMsg("1", "user", "hello"),
       makeTextMsg("2", "assistant", "hi"),
+    ];
+    const secondChunkMessages = [
       makeTextMsg("3", "user", "next"),
+      makeTextMsg("4", "assistant", "done"),
     ];
-    const sessionID = older[0]!.info.sessionID;
-    const cache = buildCompactCacheEntry(
-      older,
-      makeCompactResult("summary"),
-      buildFakeFingerprint(older),
-    );
-    const editedMiddle = [
-      older[0]!,
-      {
-        ...older[1]!,
-        parts: [{ type: "text", text: "changed answer" }] as FakePart[],
-      },
-      older[2]!,
+    const editedSecondChunk = [
+      secondChunkMessages[0]!,
+      makeTextMsg("4", "assistant", "changed"),
     ];
+    const cache = makeSessionCache("sess-1", [
+      makeChunk(firstChunkMessages, "chunk-1"),
+      makeChunk(secondChunkMessages, "chunk-2"),
+    ]);
 
     expect(
-      canReuseCompactCache(
+      matchCacheChunks(
         cache,
-        sessionID,
-        buildFakeFingerprint(editedMiddle),
+        buildFakeFingerprint([...firstChunkMessages, ...editedSecondChunk]),
       ),
-    ).toBe(false);
+    ).toEqual({
+      matchedChunks: [cache.chunks[0]!],
+      matchedMessageCount: 2,
+    });
   });
 
-  test("does not reuse cache when compaction config changes", () => {
-    const older = [
+  test("does not match cached chunks when compaction config changes", () => {
+    const chunkMessages = [
       makeTextMsg("1", "user", "hello"),
       makeTextMsg("2", "assistant", "hi"),
     ];
-    const sessionID = older[0]!.info.sessionID;
-    const cache = buildCompactCacheEntry(
-      older,
-      makeCompactResult("summary"),
-      buildFakeFingerprint(older, "cfg-v1"),
+    const cache = makeSessionCache(
+      "sess-1",
+      [makeChunk(chunkMessages, "chunk-1")],
+      "cfg-v1",
     );
 
     expect(
-      canReuseCompactCache(
-        cache,
-        sessionID,
-        buildFakeFingerprint(older, "cfg-v2"),
-      ),
-    ).toBe(false);
+      matchCacheChunks(cache, buildFakeFingerprint(chunkMessages, "cfg-v2")),
+    ).toEqual({
+      matchedChunks: [],
+      matchedMessageCount: 0,
+    });
   });
 });
 
 describe("bounded LRU compact cache", () => {
   function entryForSession(sid: string) {
-    const msgs = [makeTextMsg("1", "user", "hi")];
-    msgs[0]!.info.sessionID = sid;
-    return buildCompactCacheEntry(
-      msgs,
-      makeCompactResult(`summary-${sid}`),
-      buildFakeFingerprint(msgs, `cfg-${sid}`),
+    const chunkMessages = [makeTextMsg("1", "user", "hi")];
+    chunkMessages[0]!.info.sessionID = sid;
+    return makeSessionCache(
+      sid,
+      [makeChunk(chunkMessages, `summary-${sid}`)],
+      `cfg-${sid}`,
     );
   }
 
@@ -1042,22 +1038,14 @@ describe("compaction integration", () => {
     expect(compactInput.length).toBe(14);
     expect(compactInput.every((m) => m.content.length > 0)).toBe(true);
 
-    // Incremental cache reuses exact prefixes and can extend appended ones
-    const cache = buildCompactCacheEntry(
-      older,
-      makeCompactResult("summary"),
-      buildFakeFingerprint(older),
-    );
+    const cachedChunk = makeChunk(older.slice(0, 4), "chunk-1");
+    const cache = makeSessionCache("sess-1", [cachedChunk]);
     expect(
-      canReuseCompactCache(cache, older[0]!.info.sessionID, buildFakeFingerprint(older)),
-    ).toBe(true);
-    expect(
-      canExtendCompactCache(
-        cache,
-        older[0]!.info.sessionID,
-        buildFakeFingerprint([...older, makeTextMsg("new-id", "user", "different")]),
-      ),
-    ).toBe(true);
+      matchCacheChunks(cache, buildFakeFingerprint(older)),
+    ).toEqual({
+      matchedChunks: [cachedChunk],
+      matchedMessageCount: 4,
+    });
   });
 
   test("too few messages does not trigger compaction", () => {
@@ -1074,7 +1062,7 @@ describe("compaction integration", () => {
     expect(messages.length).toBeLessThan(PRESERVE_RECENT + 2);
   });
 
-  test("plugin hook reuses exact transcript and incrementally extends older prefixes", async () => {
+  test("plugin hook reuses exact transcript and compacts only uncached chunk suffixes", async () => {
     const originalFetch = globalThis.fetch;
     const requests: Array<{ url: string; body: any }> = [];
     const toasts: Array<{ title?: string; message: string; variant: string }> = [];
@@ -1097,6 +1085,7 @@ describe("compaction integration", () => {
           MORPH_COMPACT: "true",
           MORPH_COMPACT_CHAR_THRESHOLD: "1",
           MORPH_COMPACT_PRESERVE_RECENT: "1",
+          MORPH_COMPACT_CHUNK_SIZE: "2",
         },
         async () => {
           const mod = await import(
@@ -1146,7 +1135,7 @@ describe("compaction integration", () => {
           expect(requests).toHaveLength(1);
           expect(toasts).toHaveLength(1);
           expect(toasts[0]!.variant).toBe("success");
-          expect(toasts[0]!.message).toContain("Context compacted in");
+          expect(toasts[0]!.message).toContain("1 chunks (2 msgs compacted)");
 
           const extendedMessages = [
             ...baseMessages,
@@ -1157,18 +1146,20 @@ describe("compaction integration", () => {
 
           expect(requests).toHaveLength(2);
           expect(requests[1]!.body.messages).toEqual([
-            {
-              role: "assistant",
-              content: "[Morph Compact summary of 2 earlier messages]\n\nsummary-1",
-            },
             { role: "user", content: "C".repeat(100) },
           ]);
           expect(
-            logs.some((entry) => entry.message.includes("Compact (incremental)")),
+            logs.some((entry) => entry.message.includes("Compact chunk: 1 messages")),
           ).toBe(true);
           expect(toasts).toHaveLength(2);
           expect(toasts[1]!.variant).toBe("success");
-          expect(toasts[1]!.message).toContain("Context updated in");
+          expect(toasts[1]!.message).toContain("2 chunks (3 msgs compacted)");
+          expect(thirdOutput.messages[0]!.parts[0]!.text).toContain(
+            "--- Chunk 1/2 (2 messages) ---",
+          );
+          expect(thirdOutput.messages[0]!.parts[0]!.text).toContain(
+            "--- Chunk 2/2 (1 messages) ---",
+          );
         },
       );
     } finally {
@@ -1200,6 +1191,7 @@ describe("compaction integration", () => {
           MORPH_COMPACT: "true",
           MORPH_COMPACT_CHAR_THRESHOLD: "1",
           MORPH_COMPACT_PRESERVE_RECENT: "1",
+          MORPH_COMPACT_CHUNK_SIZE: "2",
         },
         async () => {
           const mod = await import(
@@ -1243,7 +1235,7 @@ describe("compaction integration", () => {
     }
   });
 
-  test("plugin hook defers compaction when the compaction boundary ends on an in-flight tool call", async () => {
+  test("plugin hook skips trailing in-flight older messages and compacts the settled prefix", async () => {
     const originalFetch = globalThis.fetch;
     const requests: Array<{ url: string; body: any }> = [];
 
@@ -1265,6 +1257,7 @@ describe("compaction integration", () => {
           MORPH_COMPACT: "true",
           MORPH_COMPACT_CHAR_THRESHOLD: "1",
           MORPH_COMPACT_PRESERVE_RECENT: "1",
+          MORPH_COMPACT_CHUNK_SIZE: "2",
         },
         async () => {
           const mod = await import(
@@ -1294,7 +1287,10 @@ describe("compaction integration", () => {
             },
           );
 
-          expect(requests).toHaveLength(0);
+          expect(requests).toHaveLength(1);
+          expect(requests[0]!.body.messages).toEqual([
+            { role: "user", content: "A".repeat(100) },
+          ]);
         },
       );
     } finally {
@@ -1324,6 +1320,7 @@ describe("compaction integration", () => {
           MORPH_COMPACT: "true",
           MORPH_COMPACT_CHAR_THRESHOLD: "1",
           MORPH_COMPACT_PRESERVE_RECENT: "1",
+          MORPH_COMPACT_CHUNK_SIZE: "2",
         },
         async () => {
           const mod = await import(

--- a/index.test.ts
+++ b/index.test.ts
@@ -519,6 +519,35 @@ function makeToolMsg(
   };
 }
 
+const COMPACT_ENV_KEYS = [
+  "MORPH_API_KEY",
+  "MORPH_COMPACT",
+  "MORPH_COMPACT_CHAR_THRESHOLD",
+  "MORPH_COMPACT_PRESERVE_RECENT",
+] as const;
+
+async function withCompactEnv<T>(
+  overrides: Record<string, string>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of COMPACT_ENV_KEYS) {
+    saved[key] = process.env[key];
+  }
+  Object.assign(process.env, overrides);
+  try {
+    return await fn();
+  } finally {
+    for (const key of COMPACT_ENV_KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  }
+}
+
 describe("serializePart", () => {
   test("serializes text part", () => {
     expect(serializePart({ type: "text", text: "hello world" })).toBe(
@@ -944,112 +973,83 @@ describe("compaction integration", () => {
       });
     };
 
-    const originalEnv = {
-      MORPH_API_KEY: process.env.MORPH_API_KEY,
-      MORPH_COMPACT: process.env.MORPH_COMPACT,
-      MORPH_COMPACT_CHAR_THRESHOLD: process.env.MORPH_COMPACT_CHAR_THRESHOLD,
-      MORPH_COMPACT_PRESERVE_RECENT:
-        process.env.MORPH_COMPACT_PRESERVE_RECENT,
-    };
-
-    process.env.MORPH_API_KEY = "sk-test-key";
-    process.env.MORPH_COMPACT = "true";
-    process.env.MORPH_COMPACT_CHAR_THRESHOLD = "1";
-    process.env.MORPH_COMPACT_PRESERVE_RECENT = "1";
-
     try {
-      const mod = await import(
-        `./index.ts?compaction-hook-test=${Date.now()}-${Math.random()}`
-      );
-      const plugin = mod.default;
-      const logs: any[] = [];
-      const hooks = await plugin({
-        directory: import.meta.dir,
-        client: {
-          app: {
-            log: async ({ body }: any) => {
-              logs.push(body);
-            },
-          },
-          tui: {
-            showToast: async ({ body }: any) => {
-              toasts.push(body);
-            },
-          },
-        },
-      });
-
-      const transform = hooks["experimental.chat.messages.transform"];
-      expect(typeof transform).toBe("function");
-
-      const baseMessages = [
-        makeTextMsg("1", "user", "A".repeat(100)),
-        makeTextMsg("2", "assistant", "B".repeat(100)),
-        makeTextMsg("3", "user", "C".repeat(100)),
-      ];
-
-      const firstOutput = { messages: structuredClone(baseMessages) };
-      await transform({}, firstOutput);
-      expect(requests).toHaveLength(1);
-      expect(requests[0]!.body.messages).toEqual([
-        { role: "user", content: "A".repeat(100) },
-        { role: "assistant", content: "B".repeat(100) },
-      ]);
-
-      const secondOutput = { messages: structuredClone(baseMessages) };
-      await transform({}, secondOutput);
-      expect(requests).toHaveLength(1);
-      expect(toasts).toHaveLength(1);
-      expect(toasts[0]!.variant).toBe("success");
-      expect(toasts[0]!.message).toContain("Context compacted in");
-
-      const extendedMessages = [
-        ...baseMessages,
-        makeTextMsg("4", "assistant", "D".repeat(100)),
-      ];
-      const thirdOutput = { messages: structuredClone(extendedMessages) };
-      await transform({}, thirdOutput);
-
-      expect(requests).toHaveLength(2);
-      expect(requests[1]!.body.messages).toEqual([
+      await withCompactEnv(
         {
-          role: "user",
-          content: "[Morph Compact summary of 2 earlier messages]\n\nsummary-1",
+          MORPH_API_KEY: "sk-test-key",
+          MORPH_COMPACT: "true",
+          MORPH_COMPACT_CHAR_THRESHOLD: "1",
+          MORPH_COMPACT_PRESERVE_RECENT: "1",
         },
-        { role: "user", content: "C".repeat(100) },
-      ]);
-      expect(
-        logs.some((entry) => entry.message.includes("Compact (incremental)")),
-      ).toBe(true);
-      expect(toasts).toHaveLength(1);
+        async () => {
+          const mod = await import(
+            `./index.ts?compaction-hook-test=${Date.now()}-${Math.random()}`
+          );
+          const plugin = mod.default;
+          const logs: any[] = [];
+          const hooks = await plugin({
+            directory: import.meta.dir,
+            client: {
+              app: {
+                log: async ({ body }: any) => {
+                  logs.push(body);
+                },
+              },
+              tui: {
+                showToast: async ({ body }: any) => {
+                  toasts.push(body);
+                },
+              },
+            },
+          });
+
+          const transform = hooks["experimental.chat.messages.transform"];
+          expect(typeof transform).toBe("function");
+
+          const baseMessages = [
+            makeTextMsg("1", "user", "A".repeat(100)),
+            makeTextMsg("2", "assistant", "B".repeat(100)),
+            makeTextMsg("3", "user", "C".repeat(100)),
+          ];
+
+          const firstOutput = { messages: structuredClone(baseMessages) };
+          await transform({}, firstOutput);
+          expect(requests).toHaveLength(1);
+          expect(requests[0]!.body.messages).toEqual([
+            { role: "user", content: "A".repeat(100) },
+            { role: "assistant", content: "B".repeat(100) },
+          ]);
+
+          const secondOutput = { messages: structuredClone(baseMessages) };
+          await transform({}, secondOutput);
+          expect(requests).toHaveLength(1);
+          expect(toasts).toHaveLength(1);
+          expect(toasts[0]!.variant).toBe("success");
+          expect(toasts[0]!.message).toContain("Context compacted in");
+
+          const extendedMessages = [
+            ...baseMessages,
+            makeTextMsg("4", "assistant", "D".repeat(100)),
+          ];
+          const thirdOutput = { messages: structuredClone(extendedMessages) };
+          await transform({}, thirdOutput);
+
+          expect(requests).toHaveLength(2);
+          expect(requests[1]!.body.messages).toEqual([
+            {
+              role: "user",
+              content: "[Morph Compact summary of 2 earlier messages]\n\nsummary-1",
+            },
+            { role: "user", content: "C".repeat(100) },
+          ]);
+          expect(
+            logs.some((entry) => entry.message.includes("Compact (incremental)")),
+          ).toBe(true);
+          expect(toasts).toHaveLength(1);
+        },
+      );
     } finally {
       globalThis.fetch = originalFetch;
-
-      if (originalEnv.MORPH_API_KEY === undefined) {
-        delete process.env.MORPH_API_KEY;
-      } else {
-        process.env.MORPH_API_KEY = originalEnv.MORPH_API_KEY;
-      }
-
-      if (originalEnv.MORPH_COMPACT === undefined) {
-        delete process.env.MORPH_COMPACT;
-      } else {
-        process.env.MORPH_COMPACT = originalEnv.MORPH_COMPACT;
-      }
-
-      if (originalEnv.MORPH_COMPACT_CHAR_THRESHOLD === undefined) {
-        delete process.env.MORPH_COMPACT_CHAR_THRESHOLD;
-      } else {
-        process.env.MORPH_COMPACT_CHAR_THRESHOLD =
-          originalEnv.MORPH_COMPACT_CHAR_THRESHOLD;
-      }
-
-      if (originalEnv.MORPH_COMPACT_PRESERVE_RECENT === undefined) {
-        delete process.env.MORPH_COMPACT_PRESERVE_RECENT;
-      } else {
-        process.env.MORPH_COMPACT_PRESERVE_RECENT =
-          originalEnv.MORPH_COMPACT_PRESERVE_RECENT;
-      }
     }
   });
 
@@ -1070,82 +1070,53 @@ describe("compaction integration", () => {
       });
     };
 
-    const originalEnv = {
-      MORPH_API_KEY: process.env.MORPH_API_KEY,
-      MORPH_COMPACT: process.env.MORPH_COMPACT,
-      MORPH_COMPACT_CHAR_THRESHOLD: process.env.MORPH_COMPACT_CHAR_THRESHOLD,
-      MORPH_COMPACT_PRESERVE_RECENT:
-        process.env.MORPH_COMPACT_PRESERVE_RECENT,
-    };
-
-    process.env.MORPH_API_KEY = "sk-test-key";
-    process.env.MORPH_COMPACT = "true";
-    process.env.MORPH_COMPACT_CHAR_THRESHOLD = "1";
-    process.env.MORPH_COMPACT_PRESERVE_RECENT = "1";
-
     try {
-      const mod = await import(
-        `./index.ts?compaction-pending-tool-test=${Date.now()}-${Math.random()}`
-      );
-      const plugin = mod.default;
-      const hooks = await plugin({
-        directory: import.meta.dir,
-        client: {
-          app: { log: async () => {} },
-          tui: {
-            showToast: async ({ body }: any) => {
-              toasts.push(body);
-            },
-          },
-        },
-      });
-
-      const transform = hooks["experimental.chat.messages.transform"];
-      await transform(
-        {},
+      await withCompactEnv(
         {
-          messages: structuredClone([
-            makeTextMsg("1", "user", "A".repeat(100)),
-            makeTextMsg("2", "assistant", "B".repeat(100)),
-            makeToolMsg("3", "read", {
-              status: "running",
-              input: { path: "/tmp/file.ts" },
-              title: "Reading file",
-            }),
-          ]),
+          MORPH_API_KEY: "sk-test-key",
+          MORPH_COMPACT: "true",
+          MORPH_COMPACT_CHAR_THRESHOLD: "1",
+          MORPH_COMPACT_PRESERVE_RECENT: "1",
+        },
+        async () => {
+          const mod = await import(
+            `./index.ts?compaction-pending-tool-test=${Date.now()}-${Math.random()}`
+          );
+          const plugin = mod.default;
+          const hooks = await plugin({
+            directory: import.meta.dir,
+            client: {
+              app: { log: async () => {} },
+              tui: {
+                showToast: async ({ body }: any) => {
+                  toasts.push(body);
+                },
+              },
+            },
+          });
+
+          const transform = hooks["experimental.chat.messages.transform"];
+          await transform(
+            {},
+            {
+              messages: structuredClone([
+                makeTextMsg("1", "user", "A".repeat(100)),
+                makeTextMsg("2", "assistant", "B".repeat(100)),
+                makeToolMsg("3", "read", {
+                  status: "running",
+                  input: { path: "/tmp/file.ts" },
+                  title: "Reading file",
+                }),
+              ]),
+            },
+          );
+
+          expect(requests).toHaveLength(0);
+          expect(toasts).toHaveLength(0);
         },
       );
-
-      expect(requests).toHaveLength(0);
-      expect(toasts).toHaveLength(0);
     } finally {
       globalThis.fetch = originalFetch;
-
-      if (originalEnv.MORPH_API_KEY === undefined) {
-        delete process.env.MORPH_API_KEY;
-      } else {
-        process.env.MORPH_API_KEY = originalEnv.MORPH_API_KEY;
-      }
-
-      if (originalEnv.MORPH_COMPACT === undefined) {
-        delete process.env.MORPH_COMPACT;
-      } else {
-        process.env.MORPH_COMPACT = originalEnv.MORPH_COMPACT;
-      }
-
-      if (originalEnv.MORPH_COMPACT_CHAR_THRESHOLD === undefined) {
-        delete process.env.MORPH_COMPACT_CHAR_THRESHOLD;
-      } else {
-        process.env.MORPH_COMPACT_CHAR_THRESHOLD =
-          originalEnv.MORPH_COMPACT_CHAR_THRESHOLD;
-      }
-
-      if (originalEnv.MORPH_COMPACT_PRESERVE_RECENT === undefined) {
-        delete process.env.MORPH_COMPACT_PRESERVE_RECENT;
-      } else {
-        process.env.MORPH_COMPACT_PRESERVE_RECENT =
-          originalEnv.MORPH_COMPACT_PRESERVE_RECENT;
-      }
     }
   });
 
@@ -1164,76 +1135,47 @@ describe("compaction integration", () => {
       });
     };
 
-    const originalEnv = {
-      MORPH_API_KEY: process.env.MORPH_API_KEY,
-      MORPH_COMPACT: process.env.MORPH_COMPACT,
-      MORPH_COMPACT_CHAR_THRESHOLD: process.env.MORPH_COMPACT_CHAR_THRESHOLD,
-      MORPH_COMPACT_PRESERVE_RECENT:
-        process.env.MORPH_COMPACT_PRESERVE_RECENT,
-    };
-
-    process.env.MORPH_API_KEY = "sk-test-key";
-    process.env.MORPH_COMPACT = "true";
-    process.env.MORPH_COMPACT_CHAR_THRESHOLD = "1";
-    process.env.MORPH_COMPACT_PRESERVE_RECENT = "1";
-
     try {
-      const mod = await import(
-        `./index.ts?compaction-boundary-tool-test=${Date.now()}-${Math.random()}`
-      );
-      const plugin = mod.default;
-      const hooks = await plugin({
-        directory: import.meta.dir,
-        client: {
-          app: { log: async () => {} },
-        },
-      });
-
-      const transform = hooks["experimental.chat.messages.transform"];
-      await transform(
-        {},
+      await withCompactEnv(
         {
-          messages: structuredClone([
-            makeTextMsg("1", "user", "A".repeat(100)),
-            makeToolMsg("2", "read", {
-              status: "pending",
-              input: { path: "/tmp/file.ts" },
-              raw: "{\"path\":\"/tmp/file.ts\"}",
-            }),
-            makeTextMsg("3", "user", "C".repeat(100)),
-          ]),
+          MORPH_API_KEY: "sk-test-key",
+          MORPH_COMPACT: "true",
+          MORPH_COMPACT_CHAR_THRESHOLD: "1",
+          MORPH_COMPACT_PRESERVE_RECENT: "1",
+        },
+        async () => {
+          const mod = await import(
+            `./index.ts?compaction-boundary-tool-test=${Date.now()}-${Math.random()}`
+          );
+          const plugin = mod.default;
+          const hooks = await plugin({
+            directory: import.meta.dir,
+            client: {
+              app: { log: async () => {} },
+            },
+          });
+
+          const transform = hooks["experimental.chat.messages.transform"];
+          await transform(
+            {},
+            {
+              messages: structuredClone([
+                makeTextMsg("1", "user", "A".repeat(100)),
+                makeToolMsg("2", "read", {
+                  status: "pending",
+                  input: { path: "/tmp/file.ts" },
+                  raw: "{\"path\":\"/tmp/file.ts\"}",
+                }),
+                makeTextMsg("3", "user", "C".repeat(100)),
+              ]),
+            },
+          );
+
+          expect(requests).toHaveLength(0);
         },
       );
-
-      expect(requests).toHaveLength(0);
     } finally {
       globalThis.fetch = originalFetch;
-
-      if (originalEnv.MORPH_API_KEY === undefined) {
-        delete process.env.MORPH_API_KEY;
-      } else {
-        process.env.MORPH_API_KEY = originalEnv.MORPH_API_KEY;
-      }
-
-      if (originalEnv.MORPH_COMPACT === undefined) {
-        delete process.env.MORPH_COMPACT;
-      } else {
-        process.env.MORPH_COMPACT = originalEnv.MORPH_COMPACT;
-      }
-
-      if (originalEnv.MORPH_COMPACT_CHAR_THRESHOLD === undefined) {
-        delete process.env.MORPH_COMPACT_CHAR_THRESHOLD;
-      } else {
-        process.env.MORPH_COMPACT_CHAR_THRESHOLD =
-          originalEnv.MORPH_COMPACT_CHAR_THRESHOLD;
-      }
-
-      if (originalEnv.MORPH_COMPACT_PRESERVE_RECENT === undefined) {
-        delete process.env.MORPH_COMPACT_PRESERVE_RECENT;
-      } else {
-        process.env.MORPH_COMPACT_PRESERVE_RECENT =
-          originalEnv.MORPH_COMPACT_PRESERVE_RECENT;
-      }
     }
   });
 
@@ -1252,101 +1194,72 @@ describe("compaction integration", () => {
       });
     };
 
-    const originalEnv = {
-      MORPH_API_KEY: process.env.MORPH_API_KEY,
-      MORPH_COMPACT: process.env.MORPH_COMPACT,
-      MORPH_COMPACT_CHAR_THRESHOLD: process.env.MORPH_COMPACT_CHAR_THRESHOLD,
-      MORPH_COMPACT_PRESERVE_RECENT:
-        process.env.MORPH_COMPACT_PRESERVE_RECENT,
-    };
-
-    process.env.MORPH_API_KEY = "sk-test-key";
-    process.env.MORPH_COMPACT = "true";
-    process.env.MORPH_COMPACT_CHAR_THRESHOLD = "1";
-    process.env.MORPH_COMPACT_PRESERVE_RECENT = "1";
-
     try {
-      const mod = await import(
-        `./index.ts?compaction-session-test=${Date.now()}-${Math.random()}`
+      await withCompactEnv(
+        {
+          MORPH_API_KEY: "sk-test-key",
+          MORPH_COMPACT: "true",
+          MORPH_COMPACT_CHAR_THRESHOLD: "1",
+          MORPH_COMPACT_PRESERVE_RECENT: "1",
+        },
+        async () => {
+          const mod = await import(
+            `./index.ts?compaction-session-test=${Date.now()}-${Math.random()}`
+          );
+          const plugin = mod.default;
+          const hooks = await plugin({
+            directory: import.meta.dir,
+            client: {
+              app: { log: async () => {} },
+            },
+          });
+
+          const transform = hooks["experimental.chat.messages.transform"];
+          const sessionOne = [
+            {
+              ...makeTextMsg("1", "user", "A".repeat(100)),
+              info: { id: "1", role: "user" as const, sessionID: "s1" },
+            },
+            {
+              ...makeTextMsg("2", "assistant", "B".repeat(100)),
+              info: { id: "2", role: "assistant" as const, sessionID: "s1" },
+            },
+            {
+              ...makeTextMsg("3", "user", "C".repeat(100)),
+              info: { id: "3", role: "user" as const, sessionID: "s1" },
+            },
+          ];
+          const sessionTwo = [
+            {
+              ...makeTextMsg("1", "user", "A".repeat(100)),
+              info: { id: "1", role: "user" as const, sessionID: "s2" },
+            },
+            {
+              ...makeTextMsg("2", "assistant", "B".repeat(100)),
+              info: { id: "2", role: "assistant" as const, sessionID: "s2" },
+            },
+            {
+              ...makeTextMsg("3", "user", "C".repeat(100)),
+              info: { id: "3", role: "user" as const, sessionID: "s2" },
+            },
+          ];
+
+          await transform({}, { messages: structuredClone(sessionOne) });
+          await transform({}, { messages: structuredClone(sessionTwo) });
+
+          expect(requests).toHaveLength(2);
+          expect(requests[0]!.body.messages).toEqual([
+            { role: "user", content: "A".repeat(100) },
+            { role: "assistant", content: "B".repeat(100) },
+          ]);
+          expect(requests[1]!.body.messages).toEqual([
+            { role: "user", content: "A".repeat(100) },
+            { role: "assistant", content: "B".repeat(100) },
+          ]);
+        },
       );
-      const plugin = mod.default;
-      const hooks = await plugin({
-        directory: import.meta.dir,
-        client: {
-          app: { log: async () => {} },
-        },
-      });
-
-      const transform = hooks["experimental.chat.messages.transform"];
-      const sessionOne = [
-        {
-          ...makeTextMsg("1", "user", "A".repeat(100)),
-          info: { id: "1", role: "user" as const, sessionID: "s1" },
-        },
-        {
-          ...makeTextMsg("2", "assistant", "B".repeat(100)),
-          info: { id: "2", role: "assistant" as const, sessionID: "s1" },
-        },
-        {
-          ...makeTextMsg("3", "user", "C".repeat(100)),
-          info: { id: "3", role: "user" as const, sessionID: "s1" },
-        },
-      ];
-      const sessionTwo = [
-        {
-          ...makeTextMsg("1", "user", "A".repeat(100)),
-          info: { id: "1", role: "user" as const, sessionID: "s2" },
-        },
-        {
-          ...makeTextMsg("2", "assistant", "B".repeat(100)),
-          info: { id: "2", role: "assistant" as const, sessionID: "s2" },
-        },
-        {
-          ...makeTextMsg("3", "user", "C".repeat(100)),
-          info: { id: "3", role: "user" as const, sessionID: "s2" },
-        },
-      ];
-
-      await transform({}, { messages: structuredClone(sessionOne) });
-      await transform({}, { messages: structuredClone(sessionTwo) });
-
-      expect(requests).toHaveLength(2);
-      expect(requests[0]!.body.messages).toEqual([
-        { role: "user", content: "A".repeat(100) },
-        { role: "assistant", content: "B".repeat(100) },
-      ]);
-      expect(requests[1]!.body.messages).toEqual([
-        { role: "user", content: "A".repeat(100) },
-        { role: "assistant", content: "B".repeat(100) },
-      ]);
     } finally {
       globalThis.fetch = originalFetch;
-
-      if (originalEnv.MORPH_API_KEY === undefined) {
-        delete process.env.MORPH_API_KEY;
-      } else {
-        process.env.MORPH_API_KEY = originalEnv.MORPH_API_KEY;
-      }
-
-      if (originalEnv.MORPH_COMPACT === undefined) {
-        delete process.env.MORPH_COMPACT;
-      } else {
-        process.env.MORPH_COMPACT = originalEnv.MORPH_COMPACT;
-      }
-
-      if (originalEnv.MORPH_COMPACT_CHAR_THRESHOLD === undefined) {
-        delete process.env.MORPH_COMPACT_CHAR_THRESHOLD;
-      } else {
-        process.env.MORPH_COMPACT_CHAR_THRESHOLD =
-          originalEnv.MORPH_COMPACT_CHAR_THRESHOLD;
-      }
-
-      if (originalEnv.MORPH_COMPACT_PRESERVE_RECENT === undefined) {
-        delete process.env.MORPH_COMPACT_PRESERVE_RECENT;
-      } else {
-        process.env.MORPH_COMPACT_PRESERVE_RECENT =
-          originalEnv.MORPH_COMPACT_PRESERVE_RECENT;
-      }
     }
   });
 });

--- a/index.ts
+++ b/index.ts
@@ -97,9 +97,6 @@ let compactCache: {
   result: CompactResult;
 } | null = null;
 
-/** How many new messages must enter the older window before we recompact */
-const COMPACT_RECOMPACT_INTERVAL = 4;
-
 /**
  * Normalize code_edit input from LLM tool calls.
  *
@@ -192,7 +189,7 @@ function estimateTotalChars(
  * Simple hash of message IDs for cache keying.
  */
 function hashMessageIds(messages: { info: Message }[]): string {
-  return messages.map((m) => m.info.id).join("|");
+  return messages[messages.length - 1]!.info.id;
 }
 
 /**
@@ -1055,7 +1052,7 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
 
       if (olderMessages.length === 0) return;
 
-      // Check cache — reuse if older window hasn't grown by COMPACT_RECOMPACT_INTERVAL
+      // Check cache — reuse until a new message crosses into the older window
       const currentHash = hashMessageIds(olderMessages);
       if (compactCache && compactCache.messageIdHash === currentHash) {
         // Rebuild output from cached compaction
@@ -1066,20 +1063,6 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
         );
         output.messages = [compactedMsg, ...recentMessages];
         return;
-      }
-
-      // Also reuse cache if older window grew by less than COMPACT_RECOMPACT_INTERVAL
-      if (compactCache) {
-        const cachedCount = compactCache.messageIdHash.split("|").length;
-        if (olderMessages.length - cachedCount < COMPACT_RECOMPACT_INTERVAL) {
-          const compactedMsg = buildCompactedMessage(
-            olderMessages[0]!,
-            compactCache.result,
-            olderMessages.length,
-          );
-          output.messages = [compactedMsg, ...recentMessages];
-          return;
-        }
       }
 
       // Convert to compact API format and call Morph

--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,6 @@ import { MorphClient, WarpGrepClient, CompactClient } from "@morphllm/morphsdk";
 import type { WarpGrepResult, CompactResult } from "@morphllm/morphsdk";
 import type { Part, TextPart, ToolPart, Message } from "@opencode-ai/sdk";
 import {
-  type CompactInputMessage,
   buildCompactCacheEntry,
   buildIncrementalCompactInput,
   canExtendCompactCache,

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@
 import { type Plugin, tool } from "@opencode-ai/plugin";
 import { createHash } from "node:crypto";
 import { MorphClient, WarpGrepClient, CompactClient } from "@morphllm/morphsdk";
-import type { WarpGrepResult, CompactResult } from "@morphllm/morphsdk";
+import type { WarpGrepResult } from "@morphllm/morphsdk";
 import type { Part, TextPart, ToolPart, Message } from "@opencode-ai/sdk";
 import {
   matchCacheChunks,
@@ -1187,7 +1187,7 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
       // Check existing cache for this session
       const sessionCache = compactCacheBySession.get(sessionID);
       const { matchedChunks, matchedMessageCount } = sessionCache
-        ? matchCacheChunks(sessionCache, fingerprint.messageDigests)
+        ? matchCacheChunks(sessionCache, fingerprint)
         : { matchedChunks: [] as ChunkSummary[], matchedMessageCount: 0 };
 
       // If the entire compactable prefix is already cached, reuse it.

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,14 @@ import { type Plugin, tool } from "@opencode-ai/plugin";
 import { MorphClient, WarpGrepClient, CompactClient } from "@morphllm/morphsdk";
 import type { WarpGrepResult, CompactResult } from "@morphllm/morphsdk";
 import type { Part, TextPart, ToolPart, Message } from "@opencode-ai/sdk";
+import {
+  type CompactInputMessage,
+  buildCompactCacheEntry,
+  buildIncrementalCompactInput,
+  canExtendCompactCache,
+  canReuseCompactCache,
+  createBoundedCompactCache,
+} from "./compact-cache";
 
 // Config from environment — only MORPH_API_KEY is required
 const MORPH_API_KEY = process.env.MORPH_API_KEY;
@@ -88,14 +96,17 @@ const compactClient = new CompactClient({
 });
 
 /**
- * Cache for compaction results.
- * Keyed by a hash of the message IDs that were compacted,
- * so we don't re-compact the same messages on every LLM call.
+ * Cache compaction state per session so we can reuse identical prefixes and
+ * incrementally extend previously compacted prefixes instead of recompacting
+ * the full older window on every boundary shift.
+ *
+ * Bounded LRU cache capped at MAX_COMPACT_CACHE_SESSIONS entries.
+ * Both reads and writes refresh recency; the least-recently-used session
+ * is evicted first (Map preserves insertion order).
  */
-let compactCache: {
-  messageIdHash: string;
-  result: CompactResult;
-} | null = null;
+const MAX_COMPACT_CACHE_SESSIONS = 50;
+const compactCacheBySession =
+  createBoundedCompactCache<CompactResult>(MAX_COMPACT_CACHE_SESSIONS);
 
 /**
  * Normalize code_edit input from LLM tool calls.
@@ -183,13 +194,6 @@ function estimateTotalChars(
     }
   }
   return total;
-}
-
-/**
- * Simple hash of message IDs for cache keying.
- */
-function hashMessageIds(messages: { info: Message }[]): string {
-  return messages[messages.length - 1]!.info.id;
 }
 
 /**
@@ -1052,21 +1056,46 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
 
       if (olderMessages.length === 0) return;
 
-      // Check cache — reuse until a new message crosses into the older window
-      const currentHash = hashMessageIds(olderMessages);
-      if (compactCache && compactCache.messageIdHash === currentHash) {
-        // Rebuild output from cached compaction
+      const sessionID = olderMessages[0]!.info.sessionID;
+      const sessionCache = compactCacheBySession.get(sessionID);
+      if (sessionCache && canReuseCompactCache(sessionCache, olderMessages)) {
         const compactedMsg = buildCompactedMessage(
           olderMessages[0]!,
-          compactCache.result,
+          sessionCache.result,
           olderMessages.length,
         );
         output.messages = [compactedMsg, ...recentMessages];
         return;
       }
 
-      // Convert to compact API format and call Morph
-      const compactInput = messagesToCompactInput(olderMessages);
+      let compactInput = messagesToCompactInput(olderMessages);
+      let compactionMode: "full" | "incremental" = "full";
+
+      if (sessionCache && canExtendCompactCache(sessionCache, olderMessages)) {
+        compactInput = buildIncrementalCompactInput(
+          sessionCache,
+          olderMessages,
+          messagesToCompactInput,
+        );
+        compactionMode = "incremental";
+
+        // New messages crossed into the older window but had no compactable content.
+        // Reuse the prior summary and just advance the cache boundary metadata.
+        if (compactInput.length === 1) {
+          compactCacheBySession.set(
+            sessionID,
+            buildCompactCacheEntry(olderMessages, sessionCache.result),
+          );
+          const compactedMsg = buildCompactedMessage(
+            olderMessages[0]!,
+            sessionCache.result,
+            olderMessages.length,
+          );
+          output.messages = [compactedMsg, ...recentMessages];
+          return;
+        }
+      }
+
       if (compactInput.length === 0) return;
 
       try {
@@ -1076,8 +1105,10 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
           preserveRecent: 0, // we handle preservation ourselves
         });
 
-        // Cache the result
-        compactCache = { messageIdHash: currentHash, result };
+        compactCacheBySession.set(
+          sessionID,
+          buildCompactCacheEntry(olderMessages, result),
+        );
 
         const compactedMsg = buildCompactedMessage(
           olderMessages[0]!,
@@ -1088,7 +1119,7 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
 
         await log(
           "info",
-          `Compact: ${olderMessages.length} messages → ${Math.round(result.usage.compression_ratio * 100)}% kept (${result.usage.processing_time_ms}ms)`,
+          `Compact (${compactionMode}): ${olderMessages.length} messages → ${Math.round(result.usage.compression_ratio * 100)}% kept (${result.usage.processing_time_ms}ms)`,
         );
       } catch (err) {
         // On failure, leave messages unchanged — OpenCode's built-in compaction

--- a/index.ts
+++ b/index.ts
@@ -566,7 +566,7 @@ const MorphPlugin: Plugin = async ({ directory, client }) => {
     duration = 2000,
   ) => {
     try {
-      await client.tui.showToast({
+      await client.tui?.showToast({
         body: {
           title,
           message,
@@ -1127,8 +1127,10 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
         );
         compactionMode = "incremental";
 
-        // New messages crossed into the older window but had no compactable content.
-        // Reuse the prior summary and just advance the cache boundary metadata.
+        // The delta messages all serialized to empty content (e.g., tool parts
+        // with no output yet). Safe to reuse the prior summary because empty-content
+        // messages add no information worth re-summarizing — just advance the
+        // cache boundary metadata so future checks see the updated window.
         if (compactInput.length === 1) {
           compactCacheBySession.set(
             sessionID,

--- a/index.ts
+++ b/index.ts
@@ -1208,6 +1208,7 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
 
       // Batch uncached messages into chunks of COMPACT_CHUNK_SIZE
       const newChunks: ChunkSummary[] = [];
+      let totalCompactTime = 0;
       for (let i = 0; i < uncachedMessages.length; i += COMPACT_CHUNK_SIZE) {
         const batch = uncachedMessages.slice(i, i + COMPACT_CHUNK_SIZE);
         const compactInput = messagesToCompactInput(batch);
@@ -1231,6 +1232,8 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
             output: result.output,
             charCountSaved: estimateTotalChars(batch) - result.output.length,
           });
+
+          totalCompactTime += result.usage.processing_time_ms;
 
           await log(
             "info",
@@ -1272,7 +1275,7 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
 
       await showToast(
         "success",
-        `${allChunks.length} chunks (${totalCompactedMessages} msgs compacted)`,
+        `${allChunks.length} chunks (${totalCompactedMessages} msgs compacted) | ${totalCompactTime}ms`,
       );
     };
 

--- a/index.ts
+++ b/index.ts
@@ -195,6 +195,34 @@ function estimateTotalChars(
   return total;
 }
 
+function messageHasInFlightToolPart(message: { parts: Part[] }): boolean {
+  return message.parts.some((part) => {
+    if (part.type !== "tool") return false;
+    const state = (part as ToolPart).state;
+    return state.status === "pending" || state.status === "running";
+  });
+}
+
+function shouldDeferCompaction(
+  olderMessages: { info: Message; parts: Part[] }[],
+  recentMessages: { info: Message; parts: Part[] }[],
+): boolean {
+  const boundaryMessage = olderMessages[olderMessages.length - 1];
+  if (boundaryMessage && messageHasInFlightToolPart(boundaryMessage)) {
+    return true;
+  }
+
+  if (recentMessages.some(messageHasInFlightToolPart)) {
+    return true;
+  }
+
+  const lastMessage = recentMessages[recentMessages.length - 1];
+  return (
+    lastMessage?.info.role === "assistant" &&
+    lastMessage.info.time.completed === undefined
+  );
+}
+
 /**
  * Format WarpGrep results for tool output
  */
@@ -528,6 +556,26 @@ const MorphPlugin: Plugin = async ({ directory, client }) => {
       });
     } catch {
       process.stderr.write(`[morph] ${message}\n`);
+    }
+  };
+
+  const showToast = async (
+    variant: "info" | "success" | "warning" | "error",
+    message: string,
+    title = "Morph Compact",
+    duration = 2000,
+  ) => {
+    try {
+      await client.tui.showToast({
+        body: {
+          title,
+          message,
+          variant,
+          duration,
+        },
+      });
+    } catch {
+      // TUI feedback is best-effort; keep compaction non-blocking.
     }
   };
 
@@ -1054,6 +1102,7 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
       const recentMessages = messages.slice(-COMPACT_PRESERVE_RECENT);
 
       if (olderMessages.length === 0) return;
+      if (shouldDeferCompaction(olderMessages, recentMessages)) return;
 
       const sessionID = olderMessages[0]!.info.sessionID;
       const sessionCache = compactCacheBySession.get(sessionID);
@@ -1120,12 +1169,22 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
           "info",
           `Compact (${compactionMode}): ${olderMessages.length} messages → ${Math.round(result.usage.compression_ratio * 100)}% kept (${result.usage.processing_time_ms}ms)`,
         );
+        if (compactionMode === "full") {
+          await showToast(
+            "success",
+            `Context compacted in ${result.usage.processing_time_ms}ms`,
+          );
+        }
       } catch (err) {
         // On failure, leave messages unchanged — OpenCode's built-in compaction
         // will handle context overflow if needed
         await log(
           "warn",
           `Compact failed: ${(err as Error).message}. Falling back to native compaction.`,
+        );
+        await showToast(
+          "warning",
+          "Compaction failed, falling back to native compaction.",
         );
       }
     };

--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@
  */
 
 import { type Plugin, tool } from "@opencode-ai/plugin";
+import { createHash } from "node:crypto";
 import { MorphClient, WarpGrepClient, CompactClient } from "@morphllm/morphsdk";
 import type { WarpGrepResult, CompactResult } from "@morphllm/morphsdk";
 import type { Part, TextPart, ToolPart, Message } from "@opencode-ai/sdk";
@@ -16,6 +17,7 @@ import {
   buildIncrementalCompactInput,
   canExtendCompactCache,
   canReuseCompactCache,
+  type CompactFingerprint,
   createBoundedCompactCache,
 } from "./compact-cache";
 
@@ -42,6 +44,10 @@ const COMPACT_PRESERVE_RECENT = parseInt(
 const COMPACT_RATIO = parseFloat(
   process.env.MORPH_COMPACT_RATIO || "0.3",
 );
+const COMPACT_MAX_INCREMENTAL_EXTENSIONS = parseInt(
+  process.env.MORPH_COMPACT_MAX_INCREMENTAL || "10",
+  10,
+);
 
 /**
  * Feature flags — users can disable specific capabilities.
@@ -63,6 +69,7 @@ const ALLOW_READONLY_AGENTS =
 
 /** Plugin version */
 const PLUGIN_VERSION = "2.0.0";
+const COMPACT_CACHE_SCHEMA_VERSION = 2;
 
 /** Canonical marker string used for lazy edit placeholders */
 const EXISTING_CODE_MARKER = "// ... existing code ...";
@@ -111,7 +118,7 @@ const compactCacheBySession =
  * Normalize code_edit input from LLM tool calls.
  *
  * Agents frequently wrap tool arguments in markdown fences (```lang ... ```).
- * When this is nested inside Morph's <update> XML tag, it confuses the merge
+ * When this is nested inside Morph's XML tag, it confuses the merge
  * model. This function strips a single outer fence pair using line-based parsing.
  */
 function normalizeCodeEditInput(codeEdit: string): string {
@@ -132,8 +139,8 @@ function normalizeCodeEditInput(codeEdit: string): string {
 
 /**
  * Serialize a Part into a text representation for compaction input.
- * Tool outputs, text, and reasoning are included. Other part types are
- * represented as brief markers to preserve structure without bulk.
+ * Tool outputs and visible text are included. Reasoning is intentionally
+ * excluded so internal scratchpad-like content is never sent to Morph.
  */
 function serializePart(part: Part): string {
   switch (part.type) {
@@ -153,7 +160,7 @@ function serializePart(part: Part): string {
       return `[Tool: ${tp.tool}] ${state.status}`;
     }
     case "reasoning":
-      return `[Reasoning] ${(part as { text: string }).text}`;
+      return "";
     default:
       return `[${part.type}]`;
   }
@@ -168,9 +175,49 @@ function messagesToCompactInput(
   return messages
     .map((m) => ({
       role: m.info.role,
-      content: m.parts.map(serializePart).join("\n"),
+      content: m.parts.map(serializePart).filter(Boolean).join("\n"),
     }))
     .filter((m) => m.content.length > 0);
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function buildCompactConfigDigest(): string {
+  return sha256(
+    JSON.stringify({
+      schemaVersion: COMPACT_CACHE_SCHEMA_VERSION,
+      pluginVersion: PLUGIN_VERSION,
+      compactRatio: COMPACT_RATIO,
+      preserveRecent: COMPACT_PRESERVE_RECENT,
+      morphApiUrl: MORPH_API_URL,
+      compactModel: process.env.MORPH_COMPACT_MODEL || null,
+      promptVersion: "default-v1",
+    }),
+  );
+}
+
+const COMPACT_CONFIG_DIGEST = buildCompactConfigDigest();
+
+function buildCompactionFingerprint(
+  messages: { info: Message; parts: Part[] }[],
+): CompactFingerprint {
+  const messageDigests = messages.map((message) =>
+    sha256(
+      JSON.stringify({
+        id: message.info.id,
+        role: message.info.role,
+        content: message.parts.map(serializePart).filter(Boolean),
+      }),
+    ),
+  );
+
+  return {
+    messageDigests,
+    prefixDigest: sha256(messageDigests.join("\x1e")),
+    configDigest: COMPACT_CONFIG_DIGEST,
+  };
 }
 
 /**
@@ -207,6 +254,9 @@ function shouldDeferCompaction(
   olderMessages: { info: Message; parts: Part[] }[],
   recentMessages: { info: Message; parts: Part[] }[],
 ): boolean {
+  // We only check the immediate boundary message of the older block.
+  // If we checked all of olderMessages, a single ghost "pending" tool state 
+  // from hours ago could stall compaction forever.
   const boundaryMessage = olderMessages[olderMessages.length - 1];
   if (boundaryMessage && messageHasInFlightToolPart(boundaryMessage)) {
     return true;
@@ -281,19 +331,19 @@ type GitHubRepoSuggestion = {
 
 type GitHubRepoLookupResult =
   | {
-      status: "found";
-      fullName: string;
-      defaultBranch?: string;
-      htmlUrl?: string;
-    }
+    status: "found";
+    fullName: string;
+    defaultBranch?: string;
+    htmlUrl?: string;
+  }
   | {
-      status: "not_found";
-      detail: string;
-    }
+    status: "not_found";
+    detail: string;
+  }
   | {
-      status: "unavailable";
-      detail: string;
-    };
+    status: "unavailable";
+    detail: string;
+  };
 
 const GITHUB_OWNER_REPO_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 
@@ -599,7 +649,7 @@ const MorphPlugin: Plugin = async ({ directory, client }) => {
 
   if (MORPH_EDIT_ENABLED) {
     tools.morph_edit = tool({
-        description: `Edit existing files using partial code snippets with "// ... existing code ..." markers. Morph's AI merges your changes into the full file.
+      description: `Edit existing files using partial code snippets with "// ... existing code ..." markers. Morph's AI merges your changes into the full file.
 
 WHEN TO USE morph_edit vs edit:
 - morph_edit: large files (300+ lines), multiple scattered changes, complex refactoring, whitespace-sensitive edits
@@ -627,36 +677,36 @@ DISAMBIGUATION — when a file has repeated patterns, include enough unique cont
 
 FALLBACK: If morph_edit fails (API error, timeout), use the native 'edit' tool with exact oldString/newString matching.`,
 
-        args: {
-          target_filepath: tool.schema
-            .string()
-            .describe("Path of the file to modify"),
-          instructions: tool.schema
-            .string()
-            .describe(
-              "Brief first-person description of what you're changing. Used to disambiguate uncertainty in the edit.",
-            ),
-          code_edit: tool.schema
-            .string()
-            .describe(
-              'The code changes wrapped with "// ... existing code ..." markers for unchanged sections',
-            ),
-        },
+      args: {
+        target_filepath: tool.schema
+          .string()
+          .describe("Path of the file to modify"),
+        instructions: tool.schema
+          .string()
+          .describe(
+            "Brief first-person description of what you're changing. Used to disambiguate uncertainty in the edit.",
+          ),
+        code_edit: tool.schema
+          .string()
+          .describe(
+            'The code changes wrapped with "// ... existing code ..." markers for unchanged sections',
+          ),
+      },
 
-        async execute(args, context) {
-          const { target_filepath, instructions, code_edit } = args;
-          const normalizedCodeEdit = normalizeCodeEditInput(code_edit);
+      async execute(args, context) {
+        const { target_filepath, instructions, code_edit } = args;
+        const normalizedCodeEdit = normalizeCodeEditInput(code_edit);
 
-          // Guard 1: Block readonly agents
-          if (
-            !ALLOW_READONLY_AGENTS &&
-            READONLY_AGENTS.includes(context.agent)
-          ) {
-            await log(
-              "debug",
-              `Blocked morph_edit in readonly agent: ${context.agent}`,
-            );
-            return `Error: morph_edit is not available in ${context.agent} mode.
+        // Guard 1: Block readonly agents
+        if (
+          !ALLOW_READONLY_AGENTS &&
+          READONLY_AGENTS.includes(context.agent)
+        ) {
+          await log(
+            "debug",
+            `Blocked morph_edit in readonly agent: ${context.agent}`,
+          );
+          return `Error: morph_edit is not available in ${context.agent} mode.
 
 The ${context.agent} agent is read-only and cannot modify files.
 
@@ -664,47 +714,47 @@ Options:
 1. Switch to 'build' mode (Tab key) to make changes
 2. Use the native 'edit' tool if permitted by your agent config
 3. Set MORPH_ALLOW_READONLY_AGENTS=true to override this restriction`;
-          }
+        }
 
-          const filepath = target_filepath.startsWith("/")
-            ? target_filepath
-            : `${directory}/${target_filepath}`;
+        const filepath = target_filepath.startsWith("/")
+          ? target_filepath
+          : `${directory}/${target_filepath}`;
 
-          if (!MORPH_API_KEY) {
-            return `Error: MORPH_API_KEY not configured.
+        if (!MORPH_API_KEY) {
+          return `Error: MORPH_API_KEY not configured.
 
 To use morph_edit, set the MORPH_API_KEY environment variable.
 Get your API key at: https://morphllm.com/dashboard/api-keys
 
 Alternatively, use the native 'edit' tool for this change.`;
-          }
+        }
 
-          // Read the original file
-          let originalCode: string;
-          try {
-            const file = Bun.file(filepath);
-            if (!(await file.exists())) {
-              if (!normalizedCodeEdit.includes(EXISTING_CODE_MARKER)) {
-                await Bun.write(filepath, normalizedCodeEdit);
-                return `Created new file: ${target_filepath}\n\nLines: ${normalizedCodeEdit.split("\n").length}`;
-              }
-              return `Error: File not found: ${target_filepath}
+        // Read the original file
+        let originalCode: string;
+        try {
+          const file = Bun.file(filepath);
+          if (!(await file.exists())) {
+            if (!normalizedCodeEdit.includes(EXISTING_CODE_MARKER)) {
+              await Bun.write(filepath, normalizedCodeEdit);
+              return `Created new file: ${target_filepath}\n\nLines: ${normalizedCodeEdit.split("\n").length}`;
+            }
+            return `Error: File not found: ${target_filepath}
 
 The file doesn't exist and the code_edit contains lazy markers.
 For new files, provide the complete content without "${EXISTING_CODE_MARKER}" markers.`;
-            }
-            originalCode = await file.text();
-          } catch (err) {
-            const error = err as Error;
-            return `Error reading file ${target_filepath}: ${error.message}`;
           }
+          originalCode = await file.text();
+        } catch (err) {
+          const error = err as Error;
+          return `Error reading file ${target_filepath}: ${error.message}`;
+        }
 
-          // Guard 2: Pre-flight marker check
-          const hasMarkers = normalizedCodeEdit.includes(EXISTING_CODE_MARKER);
-          const originalLineCount = originalCode.split("\n").length;
+        // Guard 2: Pre-flight marker check
+        const hasMarkers = normalizedCodeEdit.includes(EXISTING_CODE_MARKER);
+        const originalLineCount = originalCode.split("\n").length;
 
-          if (!hasMarkers && originalLineCount > 10) {
-            return `Error: Missing "${EXISTING_CODE_MARKER}" markers.
+        if (!hasMarkers && originalLineCount > 10) {
+          return `Error: Missing "${EXISTING_CODE_MARKER}" markers.
 
 Your code_edit would replace the entire file (${originalLineCount} lines) because it contains no markers.
 This is almost certainly unintended and would cause code loss.
@@ -715,52 +765,52 @@ YOUR_CHANGES_HERE
 ${EXISTING_CODE_MARKER}
 
 If you truly want to replace the entire file, use the 'write' tool instead.`;
-          }
+        }
 
-          if (!hasMarkers && originalLineCount > 3) {
-            await log(
-              "warn",
-              `No markers in code_edit for ${target_filepath} (${originalLineCount} lines). Proceeding with full replacement.`,
-            );
-          }
-
-          // Call Morph SDK to merge the edit
-          const startTime = Date.now();
-          const result = await morph.fastApply.applyEdit(
-            {
-              originalCode,
-              codeEdit: normalizedCodeEdit,
-              instructions,
-              filepath: target_filepath,
-            },
-            {
-              morphApiUrl: MORPH_API_URL,
-              generateUdiff: true,
-            },
+        if (!hasMarkers && originalLineCount > 3) {
+          await log(
+            "warn",
+            `No markers in code_edit for ${target_filepath} (${originalLineCount} lines). Proceeding with full replacement.`,
           );
-          const apiDuration = Date.now() - startTime;
+        }
 
-          if (!result.success || !result.mergedCode) {
-            return `Morph API failed: ${result.error}
+        // Call Morph SDK to merge the edit
+        const startTime = Date.now();
+        const result = await morph.fastApply.applyEdit(
+          {
+            originalCode,
+            codeEdit: normalizedCodeEdit,
+            instructions,
+            filepath: target_filepath,
+          },
+          {
+            morphApiUrl: MORPH_API_URL,
+            generateUdiff: true,
+          },
+        );
+        const apiDuration = Date.now() - startTime;
+
+        if (!result.success || !result.mergedCode) {
+          return `Morph API failed: ${result.error}
 
 Suggestion: Try using the native 'edit' tool instead with exact string replacement.
 The edit tool requires matching the exact text in the file.`;
-          }
+        }
 
-          const mergedCode = result.mergedCode;
+        const mergedCode = result.mergedCode;
 
-          // Guard 3: Marker leakage detection
-          const originalHadMarker = originalCode.includes(EXISTING_CODE_MARKER);
-          if (
-            hasMarkers &&
-            !originalHadMarker &&
-            mergedCode.includes(EXISTING_CODE_MARKER)
-          ) {
-            await log(
-              "warn",
-              `Marker leakage detected in merged output for ${target_filepath}`,
-            );
-            return `Morph API produced unsafe output for ${target_filepath}.
+        // Guard 3: Marker leakage detection
+        const originalHadMarker = originalCode.includes(EXISTING_CODE_MARKER);
+        if (
+          hasMarkers &&
+          !originalHadMarker &&
+          mergedCode.includes(EXISTING_CODE_MARKER)
+        ) {
+          await log(
+            "warn",
+            `Marker leakage detected in merged output for ${target_filepath}`,
+          );
+          return `Morph API produced unsafe output for ${target_filepath}.
 
 Detected placeholder marker text ("${EXISTING_CODE_MARKER}") in merged output.
 This means the merge model treated markers as literal code instead of expanding them.
@@ -771,21 +821,21 @@ Options:
 1. Retry with more concrete surrounding context in code_edit
 2. Use the native 'edit' tool for exact string replacement
 3. Break the change into smaller, more targeted edits`;
-          }
+        }
 
-          // Guard 4: Catastrophic truncation detection
-          const mergedLineCount = mergedCode.split("\n").length;
-          const charLoss =
-            (originalCode.length - mergedCode.length) / originalCode.length;
-          const lineLoss =
-            (originalLineCount - mergedLineCount) / originalLineCount;
+        // Guard 4: Catastrophic truncation detection
+        const mergedLineCount = mergedCode.split("\n").length;
+        const charLoss =
+          (originalCode.length - mergedCode.length) / originalCode.length;
+        const lineLoss =
+          (originalLineCount - mergedLineCount) / originalLineCount;
 
-          if (hasMarkers && charLoss > 0.6 && lineLoss > 0.5) {
-            await log(
-              "warn",
-              `Catastrophic truncation detected for ${target_filepath}: ${Math.round(charLoss * 100)}% char loss, ${Math.round(lineLoss * 100)}% line loss`,
-            );
-            return `Morph API produced a potentially destructive merge for ${target_filepath}.
+        if (hasMarkers && charLoss > 0.6 && lineLoss > 0.5) {
+          await log(
+            "warn",
+            `Catastrophic truncation detected for ${target_filepath}: ${Math.round(charLoss * 100)}% char loss, ${Math.round(lineLoss * 100)}% line loss`,
+          );
+          return `Morph API produced a potentially destructive merge for ${target_filepath}.
 
 Original: ${originalLineCount} lines (${originalCode.length} chars)
 Merged:   ${mergedLineCount} lines (${mergedCode.length} chars)
@@ -798,109 +848,109 @@ Options:
 1. Retry with more precise anchors in code_edit
 2. Use the native 'edit' tool for exact string replacement
 3. Break the change into smaller edits`;
-          }
+        }
 
-          // Write the merged result
-          try {
-            await Bun.write(filepath, mergedCode);
-          } catch (err) {
-            const error = err as Error;
-            return `Error writing file ${target_filepath}: ${error.message}`;
-          }
+        // Write the merged result
+        try {
+          await Bun.write(filepath, mergedCode);
+        } catch (err) {
+          const error = err as Error;
+          return `Error writing file ${target_filepath}: ${error.message}`;
+        }
 
-          // Use SDK-provided diff and change stats
-          const udiff = result.udiff || "No changes detected";
-          const { linesAdded, linesRemoved } = result.changes;
-          const originalLines = originalCode.split("\n").length;
-          const mergedLines = mergedCode.split("\n").length;
+        // Use SDK-provided diff and change stats
+        const udiff = result.udiff || "No changes detected";
+        const { linesAdded, linesRemoved } = result.changes;
+        const originalLines = originalCode.split("\n").length;
+        const mergedLines = mergedCode.split("\n").length;
 
-          return `Applied edit to ${target_filepath}
+        return `Applied edit to ${target_filepath}
 
 +${linesAdded} -${linesRemoved} lines | ${originalLines} -> ${mergedLines} total | ${apiDuration}ms
 
 \`\`\`diff
 ${udiff.slice(0, 3000)}${udiff.length > 3000 ? "\n... (truncated)" : ""}
 \`\`\``;
-        },
+      },
     });
   }
 
   if (MORPH_WARPGREP_ENABLED) {
     tools.warpgrep_codebase_search = tool({
-        description: `Fast agentic codebase search. Uses ripgrep, file reading, and directory listing across multiple turns to find relevant code contexts.
+      description: `Fast agentic codebase search. Uses ripgrep, file reading, and directory listing across multiple turns to find relevant code contexts.
 
 Use this for exploratory searches like "Find the authentication flow", "How does error handling work", "Where is the database connection configured". Returns relevant file sections with line numbers.
 
 For exact keyword searches (specific function names, variable names), prefer grep/ripgrep directly.`,
 
-        args: {
-          search_term: tool.schema
-            .string()
-            .describe(
-              "Natural language search query describing what to find in the codebase",
-            ),
-        },
+      args: {
+        search_term: tool.schema
+          .string()
+          .describe(
+            "Natural language search query describing what to find in the codebase",
+          ),
+      },
 
-        async execute(args) {
-          if (!MORPH_API_KEY) {
-            return `Error: MORPH_API_KEY not configured.
+      async execute(args) {
+        if (!MORPH_API_KEY) {
+          return `Error: MORPH_API_KEY not configured.
 
 To use warpgrep_codebase_search, set the MORPH_API_KEY environment variable.
 Get your API key at: https://morphllm.com/dashboard/api-keys`;
+        }
+
+        const startTime = Date.now();
+
+        try {
+          const generator = warpGrep.execute({
+            searchTerm: args.search_term,
+            repoRoot: directory,
+            streamSteps: true,
+          });
+
+          let turnCount = 0;
+          let result: WarpGrepResult;
+
+          for (; ;) {
+            const { value, done } = await generator.next();
+            if (done) {
+              result = value;
+              break;
+            }
+            turnCount = value.turn;
+            await log(
+              "debug",
+              `WarpGrep turn ${value.turn}: ${value.toolCalls?.map((tc: { name: string }) => tc.name).join(", ") ?? "..."}`,
+            );
           }
 
-          const startTime = Date.now();
+          const duration = Date.now() - startTime;
+          const contextCount = result.contexts?.length ?? 0;
 
-          try {
-            const generator = warpGrep.execute({
-              searchTerm: args.search_term,
-              repoRoot: directory,
-              streamSteps: true,
-            });
+          await log(
+            "info",
+            `WarpGrep: ${contextCount} contexts in ${turnCount} turns (${duration}ms)`,
+          );
 
-            let turnCount = 0;
-            let result: WarpGrepResult;
-
-            for (;;) {
-              const { value, done } = await generator.next();
-              if (done) {
-                result = value;
-                break;
-              }
-              turnCount = value.turn;
-              await log(
-                "debug",
-                `WarpGrep turn ${value.turn}: ${value.toolCalls?.map((tc: { name: string }) => tc.name).join(", ") ?? "..."}`,
-              );
-            }
-
-            const duration = Date.now() - startTime;
-            const contextCount = result.contexts?.length ?? 0;
-
-            await log(
-              "info",
-              `WarpGrep: ${contextCount} contexts in ${turnCount} turns (${duration}ms)`,
-            );
-
-            return formatWarpGrepResult(result);
-          } catch (err) {
-            const error = err as Error;
-            const duration = Date.now() - startTime;
-            await log(
-              "error",
-              `WarpGrep failed after ${duration}ms: ${error.message}`,
-            );
-            return `WarpGrep search failed: ${error.message}
+          return formatWarpGrepResult(result);
+        } catch (err) {
+          const error = err as Error;
+          const duration = Date.now() - startTime;
+          await log(
+            "error",
+            `WarpGrep failed after ${duration}ms: ${error.message}`,
+          );
+          return `WarpGrep search failed: ${error.message}
 
 Try rephrasing your search term or using grep for exact keyword searches.`;
-          }
-        },
+        }
+      },
     });
   }
 
   if (MORPH_WARPGREP_GITHUB_ENABLED) {
     tools.warpgrep_github_search = tool({
-        description: `Grounded code context search for public GitHub repositories. Uses Morph's hosted WarpGrep to search indexed public repos without cloning them locally.
+      description: `Grounded code context search for public GitHub repositories. Uses Morph's hosted WarpGrep to search indexed public repos without cloning them locally.
 
 PREFER this tool over web search or docs fetching when the question is about how an open-source library or SDK works internally. If the user asks how something works in a library or package from any ecosystem, find its GitHub repo and search it here instead of fetching docs URLs.
 
@@ -916,84 +966,84 @@ Provide exactly one repository locator:
 - owner_repo: "owner/repo"
 - github_url: "https://github.com/owner/repo"`,
 
-        args: {
-          search_term: tool.schema
-            .string()
-            .describe(
-              "Natural language query describing what to find or understand in the public repository",
-            ),
-          owner_repo: tool.schema
-            .string()
-            .optional()
-            .describe(
-              'GitHub repository in "owner/repo" format, for example "owner/repo"',
-            ),
-          github_url: tool.schema
-            .string()
-            .optional()
-            .describe(
-              'Full GitHub repository URL, for example "https://github.com/owner/repo"',
-            ),
-          branch: tool.schema
-            .string()
-            .optional()
-            .describe(
-              "Optional branch name to search instead of the repository default branch",
-            ),
-        },
+      args: {
+        search_term: tool.schema
+          .string()
+          .describe(
+            "Natural language query describing what to find or understand in the public repository",
+          ),
+        owner_repo: tool.schema
+          .string()
+          .optional()
+          .describe(
+            'GitHub repository in "owner/repo" format, for example "owner/repo"',
+          ),
+        github_url: tool.schema
+          .string()
+          .optional()
+          .describe(
+            'Full GitHub repository URL, for example "https://github.com/owner/repo"',
+          ),
+        branch: tool.schema
+          .string()
+          .optional()
+          .describe(
+            "Optional branch name to search instead of the repository default branch",
+          ),
+      },
 
-        async execute(args) {
-          if (!MORPH_API_KEY) {
-            return `Error: MORPH_API_KEY not configured.
+      async execute(args) {
+        if (!MORPH_API_KEY) {
+          return `Error: MORPH_API_KEY not configured.
 
 To use warpgrep_github_search, set the MORPH_API_KEY environment variable.
 Get your API key at: https://morphllm.com/dashboard/api-keys`;
-          }
+        }
 
-          const locator = resolvePublicRepoLocator(args);
-          if ("error" in locator) {
-            return locator.error;
-          }
-          const repo = locator.repo;
+        const locator = resolvePublicRepoLocator(args);
+        if ("error" in locator) {
+          return locator.error;
+        }
+        const repo = locator.repo;
 
-          const startTime = Date.now();
-          const repoLookup = await lookupGitHubRepository(repo);
+        const startTime = Date.now();
+        const repoLookup = await lookupGitHubRepository(repo);
 
-          if (repoLookup.status === "not_found") {
+        if (repoLookup.status === "not_found") {
+          const suggestions = await fetchGitHubRepoSuggestions(repo, args.search_term).catch(() => []);
+          return formatPublicRepoResolutionFailure(repo, repoLookup.detail, suggestions);
+        }
+
+        if (repoLookup.status === "unavailable") {
+          await log("warn", `GitHub repo lookup unavailable for ${repo}: ${repoLookup.detail}`);
+        }
+
+        try {
+          const result = await warpGrep.searchGitHub({
+            searchTerm: args.search_term,
+            github: repo,
+            branch: args.branch,
+          });
+
+          const duration = Date.now() - startTime;
+          const contextCount = result.contexts?.length ?? 0;
+
+          await log("info", `Public repo context: ${repo} → ${contextCount} contexts (${duration}ms)`);
+
+          if (!result.success) {
             const suggestions = await fetchGitHubRepoSuggestions(repo, args.search_term).catch(() => []);
-            return formatPublicRepoResolutionFailure(repo, repoLookup.detail, suggestions);
+            return formatPublicRepoResolutionFailure(repo, result.error, suggestions);
           }
 
-          if (repoLookup.status === "unavailable") {
-            await log("warn", `GitHub repo lookup unavailable for ${repo}: ${repoLookup.detail}`);
-          }
-
-          try {
-            const result = await warpGrep.searchGitHub({
-              searchTerm: args.search_term,
-              github: repo,
-              branch: args.branch,
-            });
-
-            const duration = Date.now() - startTime;
-            const contextCount = result.contexts?.length ?? 0;
-
-            await log("info", `Public repo context: ${repo} → ${contextCount} contexts (${duration}ms)`);
-
-            if (!result.success) {
-              const suggestions = await fetchGitHubRepoSuggestions(repo, args.search_term).catch(() => []);
-              return formatPublicRepoResolutionFailure(repo, result.error, suggestions);
-            }
-
-            return `Repository: ${repo}\n\n${formatWarpGrepResult(result)}`;
-          } catch (err) {
-            const error = err as Error;
-            const duration = Date.now() - startTime;
-            await log("error", `Public repo context search failed for ${repo} after ${duration}ms: ${error.message}`);
-            const suggestions = await fetchGitHubRepoSuggestions(repo, args.search_term).catch(() => []);
-            return formatPublicRepoResolutionFailure(repo, error.message, suggestions);
-          }
-        },
+          return `Repository: ${repo}\n\n${formatWarpGrepResult(result)}`;
+        } catch (err) {
+          const error = err as Error;
+          const duration = Date.now() - startTime;
+          await log("error", `Public repo context search failed for ${repo} after ${duration}ms: ${error.message}`);
+          const suggestions = await fetchGitHubRepoSuggestions(repo, args.search_term).catch(() => []);
+          return formatPublicRepoResolutionFailure(repo, error.message, suggestions);
+        }
+      },
     });
   }
 
@@ -1004,84 +1054,84 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
 
   // Customize tool output display in TUI
   hooks["tool.execute.after"] = async (input: any, output: any) => {
-      const morphMeta = { ...output.metadata, provider: "morph", version: PLUGIN_VERSION };
+    const morphMeta = { ...output.metadata, provider: "morph", version: PLUGIN_VERSION };
 
-      if (input.tool === "morph_edit") {
-        const fileMatch = output.output.match(/Applied edit to (.+?)\n/);
-        const statsMatch = output.output.match(/\+(\d+) -(\d+) lines/);
-        const timingMatch = output.output.match(/\| (\d+)ms/);
-        const createdMatch = output.output.match(/Created new file: (.+?)\n/);
-        const linesMatch = output.output.match(/Lines: (\d+)/);
-        const errorMatch = output.output.match(/^Error:/);
-        const blockedMatch = output.output.match(
-          /not available in (.+?) mode/,
-        );
-        const apiFailMatch = output.output.match(/^Morph API failed:/);
-        const unsafeMatch = output.output.match(
-          /^Morph API produced unsafe output for (.+?)\./,
-        );
-        const truncationMatch = output.output.match(
-          /^Morph API produced a potentially destructive merge for (.+?)\./,
-        );
+    if (input.tool === "morph_edit") {
+      const fileMatch = output.output.match(/Applied edit to (.+?)\n/);
+      const statsMatch = output.output.match(/\+(\d+) -(\d+) lines/);
+      const timingMatch = output.output.match(/\| (\d+)ms/);
+      const createdMatch = output.output.match(/Created new file: (.+?)\n/);
+      const linesMatch = output.output.match(/Lines: (\d+)/);
+      const errorMatch = output.output.match(/^Error:/);
+      const blockedMatch = output.output.match(
+        /not available in (.+?) mode/,
+      );
+      const apiFailMatch = output.output.match(/^Morph API failed:/);
+      const unsafeMatch = output.output.match(
+        /^Morph API produced unsafe output for (.+?)\./,
+      );
+      const truncationMatch = output.output.match(
+        /^Morph API produced a potentially destructive merge for (.+?)\./,
+      );
 
-        if (createdMatch) {
-          const lines = linesMatch?.[1] || "?";
-          output.title = `Morph: ${createdMatch[1]} (new, ${lines} lines)`;
-        } else if (fileMatch && statsMatch) {
-          const timing = timingMatch ? ` (${timingMatch[1]}ms)` : "";
-          output.title = `Morph: ${fileMatch[1]} +${statsMatch[1]}/-${statsMatch[2]}${timing}`;
-        } else if (unsafeMatch) {
-          output.title = `Morph: blocked (marker leakage) ${unsafeMatch[1]}`;
-        } else if (truncationMatch) {
-          output.title = `Morph: blocked (truncation) ${truncationMatch[1]}`;
-        } else if (blockedMatch) {
-          output.title = `Morph: blocked (${blockedMatch[1]} mode)`;
-        } else if (apiFailMatch) {
-          output.title = `Morph: API failed`;
-        } else if (errorMatch) {
-          output.title = `Morph: failed`;
-        }
-
-        output.metadata = morphMeta;
+      if (createdMatch) {
+        const lines = linesMatch?.[1] || "?";
+        output.title = `Morph: ${createdMatch[1]} (new, ${lines} lines)`;
+      } else if (fileMatch && statsMatch) {
+        const timing = timingMatch ? ` (${timingMatch[1]}ms)` : "";
+        output.title = `Morph: ${fileMatch[1]} +${statsMatch[1]}/-${statsMatch[2]}${timing}`;
+      } else if (unsafeMatch) {
+        output.title = `Morph: blocked (marker leakage) ${unsafeMatch[1]}`;
+      } else if (truncationMatch) {
+        output.title = `Morph: blocked (truncation) ${truncationMatch[1]}`;
+      } else if (blockedMatch) {
+        output.title = `Morph: blocked (${blockedMatch[1]} mode)`;
+      } else if (apiFailMatch) {
+        output.title = `Morph: API failed`;
+      } else if (errorMatch) {
+        output.title = `Morph: failed`;
       }
 
-      if (input.tool === "warpgrep_codebase_search") {
-        const fileMatches = output.output.match(/<file path="[^"]+"/g);
-        const failMatch = output.output.match(
-          /^(Search failed|WarpGrep search failed):/,
-        );
-        const noResultMatch = output.output.match(/^No relevant code found/m);
+      output.metadata = morphMeta;
+    }
 
-        if (failMatch) {
-          output.title = "WarpGrep: search failed";
-        } else if (noResultMatch) {
-          output.title = "WarpGrep: no results";
-        } else if (fileMatches) {
-          output.title = `WarpGrep: ${fileMatches.length} contexts`;
-        }
+    if (input.tool === "warpgrep_codebase_search") {
+      const fileMatches = output.output.match(/<file path="[^"]+"/g);
+      const failMatch = output.output.match(
+        /^(Search failed|WarpGrep search failed):/,
+      );
+      const noResultMatch = output.output.match(/^No relevant code found/m);
 
-        output.metadata = morphMeta;
+      if (failMatch) {
+        output.title = "WarpGrep: search failed";
+      } else if (noResultMatch) {
+        output.title = "WarpGrep: no results";
+      } else if (fileMatches) {
+        output.title = `WarpGrep: ${fileMatches.length} contexts`;
       }
 
-      if (input.tool === "warpgrep_github_search") {
-        const repoMatch = output.output.match(/^Repository: (.+?)$/m);
-        const fileMatches = output.output.match(/<file path="[^"]+"/g);
-        const repo = repoMatch?.[1];
+      output.metadata = morphMeta;
+    }
 
-        if (output.output.match(/^Repository resolution failed/m)) {
-          output.title = repo ? `Public repo: unresolved (${repo})` : "Public repo: unresolved";
-        } else if (output.output.match(/^Public repo context search failed/)) {
-          output.title = repo ? `Public repo: failed (${repo})` : "Public repo: search failed";
-        } else if (output.output.match(/^Repository: .+\n\nNo relevant code found/m)) {
-          output.title = repo ? `Public repo: no results (${repo})` : "Public repo: no results";
-        } else if (fileMatches) {
-          output.title = repo
-            ? `Public repo: ${repo} (${fileMatches.length} contexts)`
-            : `Public repo: ${fileMatches.length} contexts`;
-        }
+    if (input.tool === "warpgrep_github_search") {
+      const repoMatch = output.output.match(/^Repository: (.+?)$/m);
+      const fileMatches = output.output.match(/<file path="[^"]+"/g);
+      const repo = repoMatch?.[1];
 
-        output.metadata = morphMeta;
+      if (output.output.match(/^Repository resolution failed/m)) {
+        output.title = repo ? `Public repo: unresolved (${repo})` : "Public repo: unresolved";
+      } else if (output.output.match(/^Public repo context search failed/)) {
+        output.title = repo ? `Public repo: failed (${repo})` : "Public repo: search failed";
+      } else if (output.output.match(/^Repository: .+\n\nNo relevant code found/m)) {
+        output.title = repo ? `Public repo: no results (${repo})` : "Public repo: no results";
+      } else if (fileMatches) {
+        output.title = repo
+          ? `Public repo: ${repo} (${fileMatches.length} contexts)`
+          : `Public repo: ${fileMatches.length} contexts`;
       }
+
+      output.metadata = morphMeta;
+    }
   };
 
   if (MORPH_COMPACT_ENABLED) {
@@ -1105,12 +1155,17 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
       if (shouldDeferCompaction(olderMessages, recentMessages)) return;
 
       const sessionID = olderMessages[0]!.info.sessionID;
+      const olderFingerprint = buildCompactionFingerprint(olderMessages);
       const sessionCache = compactCacheBySession.get(sessionID);
-      if (sessionCache && canReuseCompactCache(sessionCache, olderMessages)) {
+      if (
+        sessionCache &&
+        canReuseCompactCache(sessionCache, sessionID, olderFingerprint)
+      ) {
         const compactedMsg = buildCompactedMessage(
           olderMessages[0]!,
           sessionCache.result,
           olderMessages.length,
+          totalChars,
         );
         output.messages = [compactedMsg, ...recentMessages];
         return;
@@ -1119,7 +1174,10 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
       let compactInput = messagesToCompactInput(olderMessages);
       let compactionMode: "full" | "incremental" = "full";
 
-      if (sessionCache && canExtendCompactCache(sessionCache, olderMessages)) {
+      if (
+        sessionCache &&
+        canExtendCompactCache(sessionCache, sessionID, olderFingerprint, COMPACT_MAX_INCREMENTAL_EXTENSIONS)
+      ) {
         compactInput = buildIncrementalCompactInput(
           sessionCache,
           olderMessages,
@@ -1134,12 +1192,18 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
         if (compactInput.length === 1) {
           compactCacheBySession.set(
             sessionID,
-            buildCompactCacheEntry(olderMessages, sessionCache.result),
+            buildCompactCacheEntry(
+              olderMessages,
+              sessionCache.result,
+              olderFingerprint,
+              sessionCache.incrementalCount,
+            ),
           );
           const compactedMsg = buildCompactedMessage(
             olderMessages[0]!,
             sessionCache.result,
             olderMessages.length,
+            totalChars,
           );
           output.messages = [compactedMsg, ...recentMessages];
           return;
@@ -1157,13 +1221,19 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
 
         compactCacheBySession.set(
           sessionID,
-          buildCompactCacheEntry(olderMessages, result),
+          buildCompactCacheEntry(
+            olderMessages,
+            result,
+            olderFingerprint,
+            compactionMode === "incremental" ? sessionCache!.incrementalCount + 1 : 0,
+          ),
         );
 
         const compactedMsg = buildCompactedMessage(
           olderMessages[0]!,
           result,
           olderMessages.length,
+          totalChars,
         );
         output.messages = [compactedMsg, ...recentMessages];
 
@@ -1171,12 +1241,12 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
           "info",
           `Compact (${compactionMode}): ${olderMessages.length} messages → ${Math.round(result.usage.compression_ratio * 100)}% kept (${result.usage.processing_time_ms}ms)`,
         );
-        if (compactionMode === "full") {
-          await showToast(
-            "success",
-            `Context compacted in ${result.usage.processing_time_ms}ms`,
-          );
-        }
+        await showToast(
+          "success",
+          compactionMode === "full"
+            ? `Context compacted in ${result.usage.processing_time_ms}ms`
+            : `Context updated in ${result.usage.processing_time_ms}ms`,
+        );
       } catch (err) {
         // On failure, leave messages unchanged — OpenCode's built-in compaction
         // will handle context overflow if needed
@@ -1213,11 +1283,27 @@ function buildCompactedMessage(
   templateMsg: { info: Message; parts: Part[] },
   result: CompactResult,
   messageCount: number,
+  originalCharCount?: number,
 ): { info: Message; parts: Part[] } {
+  const keptRatio = Math.round(result.usage.compression_ratio * 100);
+  const processingTime = result.usage.processing_time_ms;
+  const compressedCharCount = result.output.length;
+
+  let statsLine: string;
+  if (originalCharCount !== undefined) {
+    const savedChars = originalCharCount - compressedCharCount;
+    const savedK = savedChars > 1000 ? `${Math.round(savedChars / 1000)}K` : savedChars;
+    const origK = originalCharCount > 1000 ? `${Math.round(originalCharCount / 1000)}K` : originalCharCount;
+    const compK = compressedCharCount > 1000 ? `${Math.round(compressedCharCount / 1000)}K` : compressedCharCount;
+    statsLine = `[Morph Compact: ${messageCount} msgs (${origK} chars) → 1 msg (${compK} chars) | ${keptRatio}% kept, saved ${savedK} chars | ${processingTime}ms]`;
+  } else {
+    statsLine = `[Morph Compact: ${messageCount} messages compressed, ${keptRatio}% kept | ${processingTime}ms]`;
+  }
+
   return {
     info: {
       ...templateMsg.info,
-      role: "user" as const,
+      role: "assistant" as const,
     } as Message,
     parts: [
       {
@@ -1225,7 +1311,7 @@ function buildCompactedMessage(
         sessionID: templateMsg.info.sessionID,
         messageID: templateMsg.info.id,
         type: "text" as const,
-        text: `[Morph Compact: ${messageCount} messages compressed, ${Math.round(result.usage.compression_ratio * 100)}% kept]\n\n${result.output}`,
+        text: `${statsLine}\n[Background context summary of ${messageCount} earlier messages.]\n\n${result.output}`,
       } as TextPart,
     ],
   };

--- a/index.ts
+++ b/index.ts
@@ -13,10 +13,8 @@ import { MorphClient, WarpGrepClient, CompactClient } from "@morphllm/morphsdk";
 import type { WarpGrepResult, CompactResult } from "@morphllm/morphsdk";
 import type { Part, TextPart, ToolPart, Message } from "@opencode-ai/sdk";
 import {
-  buildCompactCacheEntry,
-  buildIncrementalCompactInput,
-  canExtendCompactCache,
-  canReuseCompactCache,
+  matchCacheChunks,
+  type ChunkSummary,
   type CompactFingerprint,
   createBoundedCompactCache,
 } from "./compact-cache";
@@ -44,8 +42,8 @@ const COMPACT_PRESERVE_RECENT = parseInt(
 const COMPACT_RATIO = parseFloat(
   process.env.MORPH_COMPACT_RATIO || "0.3",
 );
-const COMPACT_MAX_INCREMENTAL_EXTENSIONS = parseInt(
-  process.env.MORPH_COMPACT_MAX_INCREMENTAL || "10",
+const COMPACT_CHUNK_SIZE = parseInt(
+  process.env.MORPH_COMPACT_CHUNK_SIZE || "20",
   10,
 );
 
@@ -102,9 +100,9 @@ const compactClient = new CompactClient({
 });
 
 /**
- * Cache compaction state per session so we can reuse identical prefixes and
- * incrementally extend previously compacted prefixes instead of recompacting
- * the full older window on every boundary shift.
+ * Cache compaction state per session using append-only discrete chunks.
+ * Each chunk is an independent summary of a batch of messages, never
+ * re-summarized — eliminating rolling-summary drift entirely.
  *
  * Bounded LRU cache capped at MAX_COMPACT_CACHE_SESSIONS entries.
  * Both reads and writes refresh recency; the least-recently-used session
@@ -112,7 +110,7 @@ const compactClient = new CompactClient({
  */
 const MAX_COMPACT_CACHE_SESSIONS = 50;
 const compactCacheBySession =
-  createBoundedCompactCache<CompactResult>(MAX_COMPACT_CACHE_SESSIONS);
+  createBoundedCompactCache(MAX_COMPACT_CACHE_SESSIONS);
 
 /**
  * Normalize code_edit input from LLM tool calls.
@@ -215,7 +213,6 @@ function buildCompactionFingerprint(
 
   return {
     messageDigests,
-    prefixDigest: sha256(messageDigests.join("\x1e")),
     configDigest: COMPACT_CONFIG_DIGEST,
   };
 }
@@ -250,27 +247,44 @@ function messageHasInFlightToolPart(message: { parts: Part[] }): boolean {
   });
 }
 
-function shouldDeferCompaction(
+/**
+ * Find the safe compaction boundary within olderMessages.
+ * Returns the number of messages from the front that can be safely compacted.
+ *
+ * Instead of a binary defer-or-not decision, we walk backwards from the end
+ * of olderMessages to find the last settled message. Everything before it
+ * (inclusive) is safe to compact. Orphaned in-flight tool states deep in
+ * history no longer block compaction — they get serialized as
+ * "[Tool: x] pending" which Morph summarizes correctly.
+ *
+ * Returns 0 only if the entire recent window is still in-flight.
+ */
+function findSafeCompactionBoundary(
   olderMessages: { info: Message; parts: Part[] }[],
   recentMessages: { info: Message; parts: Part[] }[],
-): boolean {
-  // We only check the immediate boundary message of the older block.
-  // If we checked all of olderMessages, a single ghost "pending" tool state 
-  // from hours ago could stall compaction forever.
-  const boundaryMessage = olderMessages[olderMessages.length - 1];
-  if (boundaryMessage && messageHasInFlightToolPart(boundaryMessage)) {
-    return true;
-  }
-
-  if (recentMessages.some(messageHasInFlightToolPart)) {
-    return true;
-  }
-
+): number {
+  // If the assistant is still mid-generation or recent tools are running,
+  // defer entirely — the context is actively mutating.
   const lastMessage = recentMessages[recentMessages.length - 1];
-  return (
+  if (
     lastMessage?.info.role === "assistant" &&
     lastMessage.info.time.completed === undefined
-  );
+  ) {
+    return 0;
+  }
+  if (recentMessages.some(messageHasInFlightToolPart)) {
+    return 0;
+  }
+
+  // Walk backwards from the end of olderMessages to skip any trailing
+  // in-flight messages. We compact everything up to (including) the last
+  // settled message.
+  let boundary = olderMessages.length;
+  while (boundary > 0 && messageHasInFlightToolPart(olderMessages[boundary - 1]!)) {
+    boundary--;
+  }
+
+  return boundary;
 }
 
 /**
@@ -1138,6 +1152,11 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
     // Compaction: compress older messages via Morph before the LLM
     // sees them. This preempts OpenCode's built-in auto-compact (95% context).
     // Messages stay in the DB untouched; the LLM just sees a compressed view.
+    //
+    // Architecture: append-only discrete chunks.
+    // Each chunk is an independent summary of COMPACT_CHUNK_SIZE messages.
+    // Old chunks are never re-summarized, eliminating rolling-summary drift.
+    // Only the newest unmatched batch is sent to Morph on each cycle.
     hooks["experimental.chat.messages.transform"] = async (_input: any, output: any) => {
       if (!MORPH_API_KEY) return;
 
@@ -1152,113 +1171,109 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
       const recentMessages = messages.slice(-COMPACT_PRESERVE_RECENT);
 
       if (olderMessages.length === 0) return;
-      if (shouldDeferCompaction(olderMessages, recentMessages)) return;
 
-      const sessionID = olderMessages[0]!.info.sessionID;
-      const olderFingerprint = buildCompactionFingerprint(olderMessages);
+      // Find safe boundary — skip trailing in-flight messages instead of
+      // deferring entirely. This means orphaned tool states deep in history
+      // never block compaction.
+      const safeBoundary = findSafeCompactionBoundary(olderMessages, recentMessages);
+      if (safeBoundary === 0) return;
+
+      const compactableMessages = olderMessages.slice(0, safeBoundary);
+      const skippedMessages = olderMessages.slice(safeBoundary);
+
+      const sessionID = compactableMessages[0]!.info.sessionID;
+      const fingerprint = buildCompactionFingerprint(compactableMessages);
+
+      // Check existing cache for this session
       const sessionCache = compactCacheBySession.get(sessionID);
-      if (
-        sessionCache &&
-        canReuseCompactCache(sessionCache, sessionID, olderFingerprint)
-      ) {
+      const { matchedChunks, matchedMessageCount } = sessionCache
+        ? matchCacheChunks(sessionCache, fingerprint.messageDigests)
+        : { matchedChunks: [] as ChunkSummary[], matchedMessageCount: 0 };
+
+      // If the entire compactable prefix is already cached, reuse it.
+      if (matchedMessageCount === compactableMessages.length && matchedChunks.length > 0) {
         const compactedMsg = buildCompactedMessage(
-          olderMessages[0]!,
-          sessionCache.result,
-          olderMessages.length,
+          compactableMessages[0]!,
+          matchedChunks,
+          compactableMessages.length,
           totalChars,
         );
-        output.messages = [compactedMsg, ...recentMessages];
+        output.messages = [compactedMsg, ...skippedMessages, ...recentMessages];
         return;
       }
 
-      let compactInput = messagesToCompactInput(olderMessages);
-      let compactionMode: "full" | "incremental" = "full";
+      // Determine which messages still need compaction
+      const uncachedMessages = compactableMessages.slice(matchedMessageCount);
+      if (uncachedMessages.length === 0) return;
 
-      if (
-        sessionCache &&
-        canExtendCompactCache(sessionCache, sessionID, olderFingerprint, COMPACT_MAX_INCREMENTAL_EXTENSIONS)
-      ) {
-        compactInput = buildIncrementalCompactInput(
-          sessionCache,
-          olderMessages,
-          messagesToCompactInput,
-        );
-        compactionMode = "incremental";
+      // Batch uncached messages into chunks of COMPACT_CHUNK_SIZE
+      const newChunks: ChunkSummary[] = [];
+      for (let i = 0; i < uncachedMessages.length; i += COMPACT_CHUNK_SIZE) {
+        const batch = uncachedMessages.slice(i, i + COMPACT_CHUNK_SIZE);
+        const compactInput = messagesToCompactInput(batch);
+        if (compactInput.length === 0) continue;
 
-        // The delta messages all serialized to empty content (e.g., tool parts
-        // with no output yet). Safe to reuse the prior summary because empty-content
-        // messages add no information worth re-summarizing — just advance the
-        // cache boundary metadata so future checks see the updated window.
-        if (compactInput.length === 1) {
-          compactCacheBySession.set(
-            sessionID,
-            buildCompactCacheEntry(
-              olderMessages,
-              sessionCache.result,
-              olderFingerprint,
-              sessionCache.incrementalCount,
-            ),
+        try {
+          const result = await compactClient.compact({
+            messages: compactInput,
+            compressionRatio: COMPACT_RATIO,
+            preserveRecent: 0,
+          });
+
+          const batchDigests = fingerprint.messageDigests.slice(
+            matchedMessageCount + i,
+            matchedMessageCount + i + batch.length,
           );
-          const compactedMsg = buildCompactedMessage(
-            olderMessages[0]!,
-            sessionCache.result,
-            olderMessages.length,
-            totalChars,
+
+          newChunks.push({
+            messageCount: batch.length,
+            messageDigests: batchDigests,
+            output: result.output,
+            charCountSaved: estimateTotalChars(batch) - result.output.length,
+          });
+
+          await log(
+            "info",
+            `Compact chunk: ${batch.length} messages → ${Math.round(result.usage.compression_ratio * 100)}% kept (${result.usage.processing_time_ms}ms)`,
           );
-          output.messages = [compactedMsg, ...recentMessages];
-          return;
+        } catch (err) {
+          // If a chunk fails, stop here — we'll use whatever we've built so far
+          // plus the raw remaining messages. Don't let one failure lose everything.
+          await log(
+            "warn",
+            `Compact chunk failed: ${(err as Error).message}. Keeping ${batch.length} messages raw.`,
+          );
+          break;
         }
       }
 
-      if (compactInput.length === 0) return;
+      const allChunks = [...matchedChunks, ...newChunks];
+      if (allChunks.length === 0) return;
 
-      try {
-        const result = await compactClient.compact({
-          messages: compactInput,
-          compressionRatio: COMPACT_RATIO,
-          preserveRecent: 0, // we handle preservation ourselves
-        });
+      // Persist updated cache
+      const totalCompactedMessages = allChunks.reduce((sum, c) => sum + c.messageCount, 0);
+      compactCacheBySession.set(sessionID, {
+        sessionID,
+        configDigest: fingerprint.configDigest,
+        chunks: allChunks,
+        totalMessagesCompacted: totalCompactedMessages,
+      });
 
-        compactCacheBySession.set(
-          sessionID,
-          buildCompactCacheEntry(
-            olderMessages,
-            result,
-            olderFingerprint,
-            compactionMode === "incremental" ? sessionCache!.incrementalCount + 1 : 0,
-          ),
-        );
+      // Any messages beyond what we successfully chunked stay raw
+      const unchunkedMessages = compactableMessages.slice(totalCompactedMessages);
 
-        const compactedMsg = buildCompactedMessage(
-          olderMessages[0]!,
-          result,
-          olderMessages.length,
-          totalChars,
-        );
-        output.messages = [compactedMsg, ...recentMessages];
+      const compactedMsg = buildCompactedMessage(
+        compactableMessages[0]!,
+        allChunks,
+        totalCompactedMessages,
+        totalChars,
+      );
+      output.messages = [compactedMsg, ...unchunkedMessages, ...skippedMessages, ...recentMessages];
 
-        await log(
-          "info",
-          `Compact (${compactionMode}): ${olderMessages.length} messages → ${Math.round(result.usage.compression_ratio * 100)}% kept (${result.usage.processing_time_ms}ms)`,
-        );
-        await showToast(
-          "success",
-          compactionMode === "full"
-            ? `Context compacted in ${result.usage.processing_time_ms}ms`
-            : `Context updated in ${result.usage.processing_time_ms}ms`,
-        );
-      } catch (err) {
-        // On failure, leave messages unchanged — OpenCode's built-in compaction
-        // will handle context overflow if needed
-        await log(
-          "warn",
-          `Compact failed: ${(err as Error).message}. Falling back to native compaction.`,
-        );
-        await showToast(
-          "warning",
-          "Compaction failed, falling back to native compaction.",
-        );
-      }
+      await showToast(
+        "success",
+        `${allChunks.length} chunks (${totalCompactedMessages} msgs compacted)`,
+      );
     };
 
     // When OpenCode's native compaction triggers, log it
@@ -1276,29 +1291,32 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
 };
 
 /**
- * Build a synthetic message containing the compacted output.
- * Uses the first old message's metadata as a template.
+ * Build a synthetic message containing the compacted output from discrete chunks.
+ * Each chunk's summary is concatenated with a separator — old chunks are never
+ * re-summarized, preserving fidelity across arbitrarily long sessions.
  */
 function buildCompactedMessage(
   templateMsg: { info: Message; parts: Part[] },
-  result: CompactResult,
+  chunks: ChunkSummary[],
   messageCount: number,
   originalCharCount?: number,
 ): { info: Message; parts: Part[] } {
-  const keptRatio = Math.round(result.usage.compression_ratio * 100);
-  const processingTime = result.usage.processing_time_ms;
-  const compressedCharCount = result.output.length;
+  const totalSavedChars = chunks.reduce((s, c) => s + c.charCountSaved, 0);
+  const compressedCharCount = chunks.reduce((s, c) => s + c.output.length, 0);
 
   let statsLine: string;
   if (originalCharCount !== undefined) {
-    const savedChars = originalCharCount - compressedCharCount;
-    const savedK = savedChars > 1000 ? `${Math.round(savedChars / 1000)}K` : savedChars;
+    const savedK = totalSavedChars > 1000 ? `${Math.round(totalSavedChars / 1000)}K` : totalSavedChars;
     const origK = originalCharCount > 1000 ? `${Math.round(originalCharCount / 1000)}K` : originalCharCount;
     const compK = compressedCharCount > 1000 ? `${Math.round(compressedCharCount / 1000)}K` : compressedCharCount;
-    statsLine = `[Morph Compact: ${messageCount} msgs (${origK} chars) → 1 msg (${compK} chars) | ${keptRatio}% kept, saved ${savedK} chars | ${processingTime}ms]`;
+    statsLine = `[Morph Compact: ${messageCount} msgs (${origK} chars) → ${chunks.length} chunks (${compK} chars) | saved ${savedK} chars]`;
   } else {
-    statsLine = `[Morph Compact: ${messageCount} messages compressed, ${keptRatio}% kept | ${processingTime}ms]`;
+    statsLine = `[Morph Compact: ${messageCount} messages → ${chunks.length} chunks]`;
   }
+
+  const chunkTexts = chunks.map((chunk, i) =>
+    `--- Chunk ${i + 1}/${chunks.length} (${chunk.messageCount} messages) ---\n${chunk.output}`
+  );
 
   return {
     info: {
@@ -1311,7 +1329,7 @@ function buildCompactedMessage(
         sessionID: templateMsg.info.sessionID,
         messageID: templateMsg.info.id,
         type: "text" as const,
-        text: `${statsLine}\n[Background context summary of ${messageCount} earlier messages.]\n\n${result.output}`,
+        text: `${statsLine}\n[Background context summary of ${messageCount} earlier messages.]\n\n${chunkTexts.join("\n\n")}`,
       } as TextPart,
     ],
   };

--- a/index.ts
+++ b/index.ts
@@ -97,6 +97,9 @@ let compactCache: {
   result: CompactResult;
 } | null = null;
 
+/** How many new messages must enter the older window before we recompact */
+const COMPACT_RECOMPACT_INTERVAL = 4;
+
 /**
  * Normalize code_edit input from LLM tool calls.
  *
@@ -1052,7 +1055,7 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
 
       if (olderMessages.length === 0) return;
 
-      // Check cache — if we've already compacted these exact messages, reuse
+      // Check cache — reuse if older window hasn't grown by COMPACT_RECOMPACT_INTERVAL
       const currentHash = hashMessageIds(olderMessages);
       if (compactCache && compactCache.messageIdHash === currentHash) {
         // Rebuild output from cached compaction
@@ -1063,6 +1066,20 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
         );
         output.messages = [compactedMsg, ...recentMessages];
         return;
+      }
+
+      // Also reuse cache if older window grew by less than COMPACT_RECOMPACT_INTERVAL
+      if (compactCache) {
+        const cachedCount = compactCache.messageIdHash.split("|").length;
+        if (olderMessages.length - cachedCount < COMPACT_RECOMPACT_INTERVAL) {
+          const compactedMsg = buildCompactedMessage(
+            olderMessages[0]!,
+            compactCache.result,
+            olderMessages.length,
+          );
+          output.messages = [compactedMsg, ...recentMessages];
+          return;
+        }
       }
 
       // Convert to compact API format and call Morph

--- a/index.ts
+++ b/index.ts
@@ -46,6 +46,10 @@ const COMPACT_CHUNK_SIZE = parseInt(
   process.env.MORPH_COMPACT_CHUNK_SIZE || "20",
   10,
 );
+const COMPACT_MIN_UNCACHED_CHARS = parseInt(
+  process.env.MORPH_COMPACT_MIN_UNCACHED_CHARS || "16000",
+  10,
+);
 
 /**
  * Feature flags — users can disable specific capabilities.
@@ -111,6 +115,34 @@ const compactClient = new CompactClient({
 const MAX_COMPACT_CACHE_SESSIONS = 50;
 const compactCacheBySession =
   createBoundedCompactCache(MAX_COMPACT_CACHE_SESSIONS);
+const compactSessionLocks = new Map<string, Promise<void>>();
+
+async function withSessionCompactionLock<T>(
+  sessionID: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previous = compactSessionLocks.get(sessionID) || Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = previous.then(
+    () => current,
+    () => current,
+  );
+  compactSessionLocks.set(sessionID, queued);
+
+  await previous;
+
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (compactSessionLocks.get(sessionID) === queued) {
+      compactSessionLocks.delete(sessionID);
+    }
+  }
+}
 
 /**
  * Normalize code_edit input from LLM tool calls.
@@ -151,6 +183,28 @@ function serializePart(part: Part): string {
         const inputStr = JSON.stringify(state.input).slice(0, 500);
         const outputStr = (state.output || "").slice(0, 2000);
         return `[Tool: ${tp.tool}] ${inputStr}\nOutput: ${outputStr}`;
+      }
+      if (state.status === "error") {
+        return `[Tool: ${tp.tool}] Error: ${state.error}`;
+      }
+      return `[Tool: ${tp.tool}] ${state.status}`;
+    }
+    case "reasoning":
+      return "";
+    default:
+      return `[${part.type}]`;
+  }
+}
+
+function serializePartForFingerprint(part: Part): string {
+  switch (part.type) {
+    case "text":
+      return (part as TextPart).text;
+    case "tool": {
+      const tp = part as ToolPart;
+      const state = tp.state;
+      if (state.status === "completed") {
+        return `[Tool: ${tp.tool}] ${JSON.stringify(state.input)}\nOutput: ${state.output || ""}`;
       }
       if (state.status === "error") {
         return `[Tool: ${tp.tool}] Error: ${state.error}`;
@@ -206,7 +260,7 @@ function buildCompactionFingerprint(
       JSON.stringify({
         id: message.info.id,
         role: message.info.role,
-        content: message.parts.map(serializePart).filter(Boolean),
+        content: message.parts.map(serializePartForFingerprint).filter(Boolean),
       }),
     ),
   );
@@ -245,6 +299,13 @@ function messageHasInFlightToolPart(message: { parts: Part[] }): boolean {
     const state = (part as ToolPart).state;
     return state.status === "pending" || state.status === "running";
   });
+}
+
+function findStableCompactionPrefixLength(
+  messages: { parts: Part[] }[],
+): number {
+  const firstUnstableIndex = messages.findIndex(messageHasInFlightToolPart);
+  return firstUnstableIndex === -1 ? messages.length : firstUnstableIndex;
 }
 
 /**
@@ -1180,106 +1241,154 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
 
       const compactableMessages = olderMessages.slice(0, safeBoundary);
       const skippedMessages = olderMessages.slice(safeBoundary);
+      const stablePrefixLength = findStableCompactionPrefixLength(compactableMessages);
+      if (stablePrefixLength === 0) return;
 
-      const sessionID = compactableMessages[0]!.info.sessionID;
-      const fingerprint = buildCompactionFingerprint(compactableMessages);
+      const stableCompactableMessages = compactableMessages.slice(0, stablePrefixLength);
+      const unstableHistoryMessages = compactableMessages.slice(stablePrefixLength);
+      const sessionID = stableCompactableMessages[0]!.info.sessionID;
 
-      // Check existing cache for this session
-      const sessionCache = compactCacheBySession.get(sessionID);
-      const { matchedChunks, matchedMessageCount } = sessionCache
-        ? matchCacheChunks(sessionCache, fingerprint)
-        : { matchedChunks: [] as ChunkSummary[], matchedMessageCount: 0 };
+      await withSessionCompactionLock(sessionID, async () => {
+        if (unstableHistoryMessages.length > 0) {
+          await log(
+            "debug",
+            `Skipping ${unstableHistoryMessages.length} unstable messages from cacheable compaction prefix for session ${sessionID}`,
+          );
+        }
 
-      // If the entire compactable prefix is already cached, reuse it.
-      if (matchedMessageCount === compactableMessages.length && matchedChunks.length > 0) {
+        const fingerprint = buildCompactionFingerprint(stableCompactableMessages);
+
+        // Check existing cache for this session
+        const sessionCache = compactCacheBySession.get(sessionID);
+        const { matchedChunks, matchedMessageCount } = sessionCache
+          ? matchCacheChunks(sessionCache, fingerprint)
+          : { matchedChunks: [] as ChunkSummary[], matchedMessageCount: 0 };
+
+        // If the entire compactable prefix is already cached, reuse it.
+        if (
+          matchedMessageCount === stableCompactableMessages.length &&
+          matchedChunks.length > 0
+        ) {
+          const compactedMsg = buildCompactedMessage(
+            stableCompactableMessages[0]!,
+            matchedChunks,
+            stableCompactableMessages.length,
+            totalChars,
+          );
+          output.messages = [
+            compactedMsg,
+            ...unstableHistoryMessages,
+            ...skippedMessages,
+            ...recentMessages,
+          ];
+          return;
+        }
+
+        // Determine which messages still need compaction
+        const uncachedMessages = stableCompactableMessages.slice(matchedMessageCount);
+        if (uncachedMessages.length === 0) return;
+
+        const uncachedChars = estimateTotalChars(uncachedMessages);
+        if (uncachedChars < COMPACT_MIN_UNCACHED_CHARS) {
+          if (matchedChunks.length > 0) {
+            const compactedMsg = buildCompactedMessage(
+              stableCompactableMessages[0]!,
+              matchedChunks,
+              matchedMessageCount,
+              totalChars,
+            );
+            output.messages = [
+              compactedMsg,
+              ...stableCompactableMessages.slice(matchedMessageCount),
+              ...unstableHistoryMessages,
+              ...skippedMessages,
+              ...recentMessages,
+            ];
+          }
+          return;
+        }
+
+        // Batch uncached messages into chunks of COMPACT_CHUNK_SIZE
+        const newChunks: ChunkSummary[] = [];
+        let totalCompactTime = 0;
+        for (let i = 0; i < uncachedMessages.length; i += COMPACT_CHUNK_SIZE) {
+          const batch = uncachedMessages.slice(i, i + COMPACT_CHUNK_SIZE);
+          const compactInput = messagesToCompactInput(batch);
+          if (compactInput.length === 0) continue;
+
+          try {
+            const result = await compactClient.compact({
+              messages: compactInput,
+              compressionRatio: COMPACT_RATIO,
+              preserveRecent: 0,
+            });
+
+            const batchDigests = fingerprint.messageDigests.slice(
+              matchedMessageCount + i,
+              matchedMessageCount + i + batch.length,
+            );
+
+            newChunks.push({
+              messageCount: batch.length,
+              messageDigests: batchDigests,
+              output: result.output,
+              charCountSaved: estimateTotalChars(batch) - result.output.length,
+            });
+
+            totalCompactTime += result.usage.processing_time_ms;
+
+            await log(
+              "info",
+              `Compact chunk: ${batch.length} messages → ${Math.round(result.usage.compression_ratio * 100)}% kept (${result.usage.processing_time_ms}ms)`,
+            );
+          } catch (err) {
+            // If a chunk fails, stop here — we'll use whatever we've built so far
+            // plus the raw remaining messages. Don't let one failure lose everything.
+            await log(
+              "warn",
+              `Compact chunk failed: ${(err as Error).message}. Keeping ${batch.length} messages raw.`,
+            );
+            break;
+          }
+        }
+
+        const allChunks = [...matchedChunks, ...newChunks];
+        if (allChunks.length === 0) return;
+
+        const totalCompactedMessages = allChunks.reduce((sum, c) => sum + c.messageCount, 0);
+
+        // Persist updated cache (only for sessions that triggered compaction)
+        if (totalChars >= COMPACT_CHAR_THRESHOLD) {
+          compactCacheBySession.set(sessionID, {
+            sessionID,
+            configDigest: fingerprint.configDigest,
+            chunks: allChunks,
+            totalMessagesCompacted: totalCompactedMessages,
+          });
+        }
+
+        // Any messages beyond what we successfully chunked stay raw
+        const unchunkedMessages = stableCompactableMessages.slice(totalCompactedMessages);
+
         const compactedMsg = buildCompactedMessage(
-          compactableMessages[0]!,
-          matchedChunks,
-          compactableMessages.length,
+          stableCompactableMessages[0]!,
+          allChunks,
+          totalCompactedMessages,
           totalChars,
         );
-        output.messages = [compactedMsg, ...skippedMessages, ...recentMessages];
-        return;
-      }
+        output.messages = [
+          compactedMsg,
+          ...unchunkedMessages,
+          ...unstableHistoryMessages,
+          ...skippedMessages,
+          ...recentMessages,
+        ];
 
-      // Determine which messages still need compaction
-      const uncachedMessages = compactableMessages.slice(matchedMessageCount);
-      if (uncachedMessages.length === 0) return;
-
-      // Batch uncached messages into chunks of COMPACT_CHUNK_SIZE
-      const newChunks: ChunkSummary[] = [];
-      let totalCompactTime = 0;
-      for (let i = 0; i < uncachedMessages.length; i += COMPACT_CHUNK_SIZE) {
-        const batch = uncachedMessages.slice(i, i + COMPACT_CHUNK_SIZE);
-        const compactInput = messagesToCompactInput(batch);
-        if (compactInput.length === 0) continue;
-
-        try {
-          const result = await compactClient.compact({
-            messages: compactInput,
-            compressionRatio: COMPACT_RATIO,
-            preserveRecent: 0,
-          });
-
-          const batchDigests = fingerprint.messageDigests.slice(
-            matchedMessageCount + i,
-            matchedMessageCount + i + batch.length,
-          );
-
-          newChunks.push({
-            messageCount: batch.length,
-            messageDigests: batchDigests,
-            output: result.output,
-            charCountSaved: estimateTotalChars(batch) - result.output.length,
-          });
-
-          totalCompactTime += result.usage.processing_time_ms;
-
-          await log(
-            "info",
-            `Compact chunk: ${batch.length} messages → ${Math.round(result.usage.compression_ratio * 100)}% kept (${result.usage.processing_time_ms}ms)`,
-          );
-        } catch (err) {
-          // If a chunk fails, stop here — we'll use whatever we've built so far
-          // plus the raw remaining messages. Don't let one failure lose everything.
-          await log(
-            "warn",
-            `Compact chunk failed: ${(err as Error).message}. Keeping ${batch.length} messages raw.`,
-          );
-          break;
-        }
-      }
-
-      const allChunks = [...matchedChunks, ...newChunks];
-      if (allChunks.length === 0) return;
-
-      const totalCompactedMessages = allChunks.reduce((sum, c) => sum + c.messageCount, 0);
-
-      // Persist updated cache (only for sessions that triggered compaction)
-      if (totalChars >= COMPACT_CHAR_THRESHOLD) {
-        compactCacheBySession.set(sessionID, {
-          sessionID,
-          configDigest: fingerprint.configDigest,
-          chunks: allChunks,
-          totalMessagesCompacted: totalCompactedMessages,
-        });
-      }
-
-      // Any messages beyond what we successfully chunked stay raw
-      const unchunkedMessages = compactableMessages.slice(totalCompactedMessages);
-
-      const compactedMsg = buildCompactedMessage(
-        compactableMessages[0]!,
-        allChunks,
-        totalCompactedMessages,
-        totalChars,
-      );
-      output.messages = [compactedMsg, ...unchunkedMessages, ...skippedMessages, ...recentMessages];
-
-      await showToast(
-        "success",
-        `${allChunks.length} chunks (${totalCompactedMessages} msgs compacted) | ${totalCompactTime}ms`,
-      );
+        await showToast(
+          "success",
+          `${allChunks.length} chunks (${totalCompactedMessages} msgs compacted) | ${totalCompactTime}ms`,
+        );
+      });
     };
 
     // When OpenCode's native compaction triggers, log it

--- a/index.ts
+++ b/index.ts
@@ -1253,14 +1253,17 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
       const allChunks = [...matchedChunks, ...newChunks];
       if (allChunks.length === 0) return;
 
-      // Persist updated cache
       const totalCompactedMessages = allChunks.reduce((sum, c) => sum + c.messageCount, 0);
-      compactCacheBySession.set(sessionID, {
-        sessionID,
-        configDigest: fingerprint.configDigest,
-        chunks: allChunks,
-        totalMessagesCompacted: totalCompactedMessages,
-      });
+
+      // Persist updated cache (only for sessions that triggered compaction)
+      if (totalChars >= COMPACT_CHAR_THRESHOLD) {
+        compactCacheBySession.set(sessionID, {
+          sessionID,
+          configDigest: fingerprint.configDigest,
+          chunks: allChunks,
+          totalMessagesCompacted: totalCompactedMessages,
+        });
+      }
 
       // Any messages beyond what we successfully chunked stay raw
       const unchunkedMessages = compactableMessages.slice(totalCompactedMessages);


### PR DESCRIPTION
## Summary
- replace the moving-window compact cache with a session-scoped incremental cache
- reuse exact compacted prefixes, extend append-only prefixes incrementally, and bound cache growth with LRU eviction
- extract compact cache helpers into a shared module and add hook-level tests for reuse, incremental extension, session isolation, and eviction

## Testing
- bun test
- bun run typecheck