### PR TITLE
fix: reuse compaction prefixes per session

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ Then reference it in your `opencode.json`:
   }                                  }
   // ... existing code ...           export default validateToken;
 
-  ┌──────────┐    ┌───────────┐    ┌──────────┐    ┌──────────┐
+  ┌───────────┐    ┌───────────┐    ┌──────────┐    ┌──────────┐
   │ code_edit │───>│ Morph API │───>│ safety   │───>│ write to │
-  │ + file   │    │ merge     │    │ guards   │    │ disk     │
-  └──────────┘    └───────────┘    └──────────┘    └──────────┘
+  │ + file    │    │ merge     │    │ guards   │    │ disk     │
+  └───────────┘    └───────────┘    └──────────┘    └──────────┘
                                     marker leak?
                                     truncation?
 ```
@@ -137,18 +137,18 @@ If the repo locator is wrong, the tool now returns a resolver-style failure with
 
 ## State-of-the-Art Compaction
 
-25,000+ tok/s context compression in under 2 seconds. +0.6% on SWE-Bench Pro, where summarization-based compaction methods all hurt performance. Fires at 140k chars (~35k tokens), before OpenCode's built-in auto-compact (95% context window). Results cached per message set.
+25,000+ tok/s context compression in under 2 seconds. +0.6% on SWE-Bench Pro, where summarization-based compaction methods all hurt performance. Fires at 100k chars (roughly ~25k tokens, depending on content), before OpenCode's built-in auto-compact (95% context window). Results cached per message set.
 
 ```
   Every LLM call                      Only fires when context is large
 
   ┌───────────────────────────────────────────────────┐
-  │              Message History (20 msgs)             │
+  │              Message History (20 msgs)            │
   │  msg1  msg2  msg3  ...  msg14 │ msg15 ... msg20   │
   │  ──────── older ─────────────   ── recent (6) ──  │
   └───────────────────────────────────────────────────┘
                     │                       │
-        total > 140k chars?                  │
+        total > 100k chars?                 │
                     │                       │
                     v                       │
           ┌─────────────────┐               │
@@ -191,7 +191,7 @@ If the repo locator is wrong, the tool now returns a resolver-style failure with
 | `MORPH_WARPGREP` | `true` | Set `false` to disable WarpGrep |
 | `MORPH_WARPGREP_GITHUB` | `true` | Set `false` to disable public repo context search |
 | `MORPH_COMPACT` | `true` | Set `false` to disable compaction |
-| `MORPH_COMPACT_CHAR_THRESHOLD` | `140000` | Char count before compaction triggers |
+| `MORPH_COMPACT_CHAR_THRESHOLD` | `100000` | Char count before compaction triggers |
 | `MORPH_COMPACT_RATIO` | `0.3` | Compression ratio (0.05-1.0, lower = more aggressive) |
 
 ---

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { CompactClient } from "@morphllm/morphsdk";
@@ -402,8 +403,51 @@ function estimateTotalChars(messages: FakeMessage[]): number {
   return total;
 }
 
-function hashMessageIds(messages: { info: { id: string } }[]): string {
-  return messages.map((m) => m.info.id).join("|");
+type FakeCompactCacheChunk = {
+  messageKeys: string[];
+  result: { output: string };
+};
+
+function getMessageCacheKey(message: FakeMessage): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        id: message.info.id,
+        role: message.info.role,
+        parts: message.parts.map((part) => ({
+          type: part.type,
+          content: serializePart(part),
+        })),
+      }),
+    )
+    .digest("hex");
+}
+
+function getMessageCacheKeys(messages: FakeMessage[]): string[] {
+  return messages.map(getMessageCacheKey);
+}
+
+function getMatchedCompactChunks(
+  cachedChunks: FakeCompactCacheChunk[],
+  messageKeys: string[],
+): { matchedChunks: FakeCompactCacheChunk[]; matchedMessageCount: number } {
+  const matchedChunks: FakeCompactCacheChunk[] = [];
+  let matchedMessageCount = 0;
+
+  for (const chunk of cachedChunks) {
+    const nextCount = matchedMessageCount + chunk.messageKeys.length;
+    if (nextCount > messageKeys.length) break;
+
+    const matches = chunk.messageKeys.every(
+      (key, index) => messageKeys[matchedMessageCount + index] === key,
+    );
+    if (!matches) break;
+
+    matchedChunks.push(chunk);
+    matchedMessageCount = nextCount;
+  }
+
+  return { matchedChunks, matchedMessageCount };
 }
 
 // Helpers to build fake messages for tests
@@ -611,22 +655,63 @@ describe("estimateTotalChars", () => {
   });
 });
 
-describe("hashMessageIds", () => {
-  test("joins message IDs with pipe", () => {
+describe("getMessageCacheKey", () => {
+  test("is stable for the same message", () => {
+    const message = makeTextMsg("abc", "user", "hello");
+    expect(getMessageCacheKey(message)).toBe(getMessageCacheKey(message));
+  });
+
+  test("changes when message role changes", () => {
+    const userMessage = makeTextMsg("abc", "user", "hello");
+    const assistantMessage = makeTextMsg("abc", "assistant", "hello");
+    expect(getMessageCacheKey(userMessage)).not.toBe(
+      getMessageCacheKey(assistantMessage),
+    );
+  });
+
+  test("changes when serialized content changes", () => {
+    const first = makeToolMsg("tool-1", "read", { path: "/a" }, "one");
+    const second = makeToolMsg("tool-1", "read", { path: "/a" }, "two");
+    expect(getMessageCacheKey(first)).not.toBe(getMessageCacheKey(second));
+  });
+});
+
+describe("getMatchedCompactChunks", () => {
+  test("matches cached prefix chunks in order", () => {
     const messages = [
-      { info: { id: "abc" } },
-      { info: { id: "def" } },
-      { info: { id: "ghi" } },
+      makeTextMsg("1", "user", "a"),
+      makeTextMsg("2", "assistant", "b"),
+      makeTextMsg("3", "user", "c"),
+      makeTextMsg("4", "assistant", "d"),
     ];
-    expect(hashMessageIds(messages)).toBe("abc|def|ghi");
+    const keys = getMessageCacheKeys(messages);
+    const cachedChunks: FakeCompactCacheChunk[] = [
+      { messageKeys: keys.slice(0, 2), result: { output: "chunk-1" } },
+      { messageKeys: keys.slice(2, 3), result: { output: "chunk-2" } },
+    ];
+
+    expect(getMatchedCompactChunks(cachedChunks, keys)).toEqual({
+      matchedChunks: cachedChunks,
+      matchedMessageCount: 3,
+    });
   });
 
-  test("returns empty string for empty array", () => {
-    expect(hashMessageIds([])).toBe("");
-  });
+  test("stops matching when the prefix diverges", () => {
+    const messages = [
+      makeTextMsg("1", "user", "a"),
+      makeTextMsg("2", "assistant", "b"),
+      makeTextMsg("3", "user", "c"),
+    ];
+    const keys = getMessageCacheKeys(messages);
+    const cachedChunks: FakeCompactCacheChunk[] = [
+      { messageKeys: keys.slice(0, 2), result: { output: "chunk-1" } },
+      { messageKeys: ["wrong-key"], result: { output: "chunk-2" } },
+    ];
 
-  test("handles single message", () => {
-    expect(hashMessageIds([{ info: { id: "only" } }])).toBe("only");
+    expect(getMatchedCompactChunks(cachedChunks, keys)).toEqual({
+      matchedChunks: [cachedChunks[0]!],
+      matchedMessageCount: 2,
+    });
   });
 });
 
@@ -690,7 +775,7 @@ describe("compaction integration", () => {
 
   test("proactive compaction threshold logic", () => {
     // Simulate the decision flow from experimental.chat.messages.transform
-    const THRESHOLD = 140000;
+    const THRESHOLD = 100000;
     const PRESERVE_RECENT = 6;
 
     // Below threshold — no compaction
@@ -720,17 +805,35 @@ describe("compaction integration", () => {
     expect(compactInput.length).toBe(14);
     expect(compactInput.every((m) => m.content.length > 0)).toBe(true);
 
-    // Hash is stable
-    const hash1 = hashMessageIds(older);
-    const hash2 = hashMessageIds(older);
-    expect(hash1).toBe(hash2);
+    const olderKeys = getMessageCacheKeys(older);
+    expect(olderKeys).toHaveLength(14);
+    expect(olderKeys[0]).toHaveLength(64);
+  });
 
-    // Hash changes when messages change
-    const differentOlder = [
-      ...older.slice(0, -1),
-      makeTextMsg("new-id", "user", "different"),
+  test("prefix reuse leaves small uncached deltas un-compacted", () => {
+    const PRESERVE_RECENT = 6;
+    const older = [
+      makeTextMsg("1", "user", "x".repeat(35000)),
+      makeTextMsg("2", "assistant", "x".repeat(35000)),
+      makeTextMsg("3", "user", "x".repeat(35000)),
+      makeTextMsg("4", "assistant", "x".repeat(4000)),
     ];
-    expect(hashMessageIds(differentOlder)).not.toBe(hash1);
+    const recent = Array.from({ length: PRESERVE_RECENT }, (_, i) =>
+      makeTextMsg(`recent-${i}`, i % 2 === 0 ? "user" : "assistant", "recent"),
+    );
+    const messages = [...older, ...recent];
+    const olderKeys = getMessageCacheKeys(older);
+    const cachedChunks: FakeCompactCacheChunk[] = [
+      { messageKeys: olderKeys.slice(0, 3), result: { output: "cached-prefix" } },
+    ];
+
+    const { matchedMessageCount } = getMatchedCompactChunks(cachedChunks, olderKeys);
+    const uncachedOlderMessages = older.slice(matchedMessageCount);
+
+    expect(estimateTotalChars(messages)).toBeGreaterThan(100000);
+    expect(estimateTotalChars(uncachedOlderMessages)).toBeLessThan(16000);
+    expect(matchedMessageCount).toBe(3);
+    expect(uncachedOlderMessages).toHaveLength(1);
   });
 
   test("too few messages does not trigger compaction", () => {

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ import { type Plugin, tool } from "@opencode-ai/plugin";
 import { MorphClient, WarpGrepClient, CompactClient } from "@morphllm/morphsdk";
 import type { WarpGrepResult, CompactResult } from "@morphllm/morphsdk";
 import type { Part, TextPart, ToolPart, Message } from "@opencode-ai/sdk";
+import { createHash } from "node:crypto";
 
 // Config from environment — only MORPH_API_KEY is required
 const MORPH_API_KEY = process.env.MORPH_API_KEY;
@@ -34,6 +35,10 @@ const COMPACT_PRESERVE_RECENT = parseInt(
 );
 const COMPACT_RATIO = parseFloat(
   process.env.MORPH_COMPACT_RATIO || "0.3",
+);
+const COMPACT_MIN_UNCACHED_CHARS = parseInt(
+  process.env.MORPH_COMPACT_MIN_UNCACHED_CHARS || "16000",
+  10,
 );
 
 /**
@@ -88,14 +93,16 @@ const compactClient = new CompactClient({
 });
 
 /**
- * Cache for compaction results.
- * Keyed by a hash of the message IDs that were compacted,
- * so we don't re-compact the same messages on every LLM call.
+ * Per-session compaction cache.
+ * Stores incrementally compacted prefix chunks so a growing conversation
+ * can reuse prior compaction work instead of recompacting the full old window.
  */
-let compactCache: {
-  messageIdHash: string;
+type CompactCacheChunk = {
+  messageKeys: string[];
   result: CompactResult;
-} | null = null;
+};
+
+const compactCache = new Map<string, CompactCacheChunk[]>();
 
 /**
  * Normalize code_edit input from LLM tool calls.
@@ -185,11 +192,69 @@ function estimateTotalChars(
   return total;
 }
 
-/**
- * Simple hash of message IDs for cache keying.
- */
-function hashMessageIds(messages: { info: Message }[]): string {
-  return messages.map((m) => m.info.id).join("|");
+function getMessageCacheKey(message: { info: Message; parts: Part[] }): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        id: message.info.id,
+        role: message.info.role,
+        parts: message.parts.map((part) => ({
+          type: part.type,
+          content: serializePart(part),
+        })),
+      }),
+    )
+    .digest("hex");
+}
+
+function getMessageCacheKeys(
+  messages: { info: Message; parts: Part[] }[],
+): string[] {
+  return messages.map(getMessageCacheKey);
+}
+
+function getMatchedCompactChunks(
+  cachedChunks: CompactCacheChunk[],
+  messageKeys: string[],
+): { matchedChunks: CompactCacheChunk[]; matchedMessageCount: number } {
+  const matchedChunks: CompactCacheChunk[] = [];
+  let matchedMessageCount = 0;
+
+  for (const chunk of cachedChunks) {
+    const nextCount = matchedMessageCount + chunk.messageKeys.length;
+    if (nextCount > messageKeys.length) break;
+
+    const matches = chunk.messageKeys.every(
+      (key, index) => messageKeys[matchedMessageCount + index] === key,
+    );
+    if (!matches) break;
+
+    matchedChunks.push(chunk);
+    matchedMessageCount = nextCount;
+  }
+
+  return { matchedChunks, matchedMessageCount };
+}
+
+function buildCompactedMessagesFromChunks(
+  chunks: CompactCacheChunk[],
+  sourceMessages: { info: Message; parts: Part[] }[],
+): { info: Message; parts: Part[] }[] {
+  const compactedMessages: { info: Message; parts: Part[] }[] = [];
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    compactedMessages.push(
+      buildCompactedMessage(
+        sourceMessages[offset]!,
+        chunk.result,
+        chunk.messageKeys.length,
+      ),
+    );
+    offset += chunk.messageKeys.length;
+  }
+
+  return compactedMessages;
 }
 
 /**
@@ -526,6 +591,17 @@ const MorphPlugin: Plugin = async ({ directory, client }) => {
     } catch {
       process.stderr.write(`[morph] ${message}\n`);
     }
+  };
+
+  const showToast = async (
+    variant: "info" | "success" | "warning" | "error",
+    message: string,
+  ) => {
+    try {
+      await client.tui?.showToast({
+        body: { title: "Morph Compact", message, variant, duration: 2000 },
+      });
+    } catch {}
   };
 
   if (!MORPH_API_KEY) {
@@ -1052,43 +1128,79 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
 
       if (olderMessages.length === 0) return;
 
-      // Check cache — if we've already compacted these exact messages, reuse
-      const currentHash = hashMessageIds(olderMessages);
-      if (compactCache && compactCache.messageIdHash === currentHash) {
-        // Rebuild output from cached compaction
-        const compactedMsg = buildCompactedMessage(
-          olderMessages[0]!,
-          compactCache.result,
-          olderMessages.length,
-        );
-        output.messages = [compactedMsg, ...recentMessages];
+      const sessionID = olderMessages[0]!.info.sessionID;
+      const olderMessageKeys = getMessageCacheKeys(olderMessages);
+      const sessionCache = compactCache.get(sessionID) ?? [];
+      const { matchedChunks, matchedMessageCount } = getMatchedCompactChunks(
+        sessionCache,
+        olderMessageKeys,
+      );
+      if (matchedChunks.length !== sessionCache.length) {
+        compactCache.set(sessionID, matchedChunks);
+      }
+
+      const cachedCompactedMessages = buildCompactedMessagesFromChunks(
+        matchedChunks,
+        olderMessages,
+      );
+      const uncachedOlderMessages = olderMessages.slice(matchedMessageCount);
+
+      if (uncachedOlderMessages.length === 0) {
+        output.messages = [...cachedCompactedMessages, ...recentMessages];
         return;
       }
 
-      // Convert to compact API format and call Morph
-      const compactInput = messagesToCompactInput(olderMessages);
+      const uncachedChars = estimateTotalChars(uncachedOlderMessages);
+      if (uncachedChars < COMPACT_MIN_UNCACHED_CHARS) {
+        if (cachedCompactedMessages.length > 0) {
+          output.messages = [
+            ...cachedCompactedMessages,
+            ...uncachedOlderMessages,
+            ...recentMessages,
+          ];
+        }
+        return;
+      }
+
+      const compactInput = messagesToCompactInput(uncachedOlderMessages);
       if (compactInput.length === 0) return;
 
       try {
         const result = await compactClient.compact({
           messages: compactInput,
           compressionRatio: COMPACT_RATIO,
-          preserveRecent: 0, // we handle preservation ourselves
+          preserveRecent: 0,
         });
 
-        // Cache the result
-        compactCache = { messageIdHash: currentHash, result };
+        const newChunk: CompactCacheChunk = {
+          messageKeys: olderMessageKeys.slice(matchedMessageCount),
+          result,
+        };
+        const updatedChunks = [...matchedChunks, newChunk];
+        compactCache.set(sessionID, updatedChunks);
 
         const compactedMsg = buildCompactedMessage(
-          olderMessages[0]!,
+          uncachedOlderMessages[0]!,
           result,
-          olderMessages.length,
+          uncachedOlderMessages.length,
         );
-        output.messages = [compactedMsg, ...recentMessages];
+        output.messages = [
+          ...cachedCompactedMessages,
+          compactedMsg,
+          ...recentMessages,
+        ];
 
         await log(
           "info",
-          `Compact: ${olderMessages.length} messages → ${Math.round(result.usage.compression_ratio * 100)}% kept (${result.usage.processing_time_ms}ms)`,
+          matchedMessageCount > 0
+            ? `Compact: ${uncachedOlderMessages.length} new messages → ${Math.round(result.usage.compression_ratio * 100)}% kept (${result.usage.processing_time_ms}ms, ${matchedMessageCount} cached)`
+            : `Compact: ${uncachedOlderMessages.length} messages → ${Math.round(result.usage.compression_ratio * 100)}% kept (${result.usage.processing_time_ms}ms)`,
+        );
+        await showToast(
+          "success",
+          matchedMessageCount > 0
+            ? `${uncachedOlderMessages.length} new messages compacted (${matchedMessageCount} cached) | ${result.usage.processing_time_ms}ms`
+            : `${uncachedOlderMessages.length} messages compacted (${Math.round(result.usage.compression_ratio * 100)}% kept) | ${result.usage.processing_time_ms}ms`,
         );
       } catch (err) {
         // On failure, leave messages unchanged — OpenCode's built-in compaction


### PR DESCRIPTION
## Summary
- Cache compacted conversation prefixes per session so repeated compactions reuse old results instead of reprocessing the whole history
- Use content-based SHA-256 keys (role + message content) instead of raw string concatenation
- Only compact the new uncached portion; skip if the delta is too small
- Add a success toast after compaction
- Update README

## Screenshot
<img width="1158" height="1302" alt="image" src="https://github.com/user-attachments/assets/c6ac12de-e839-4ff8-b886-bfd2e711e68f" />