### PR TITLE
Fix streamed WarpGrep result handling

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -1013,6 +1013,26 @@ describe("formatWarpGrepResult edge cases", () => {
     }
   }
 
+  test("awaits promised final result from streaming WarpGrep execution", async () => {
+    const result = await executeSearch(
+      Promise.resolve({
+        success: true,
+        contexts: [
+          {
+            file: "src/search.ts",
+            content: "export const search = true;",
+            lines: [[1, 1]] as Array<[number, number]>,
+          },
+        ],
+      }),
+    );
+
+    expect(result).toContain("Relevant context found:");
+    expect(result).toContain("- src/search.ts:1-1");
+    expect(result).toContain('<file path="src/search.ts" lines="1-1">');
+    expect(result).not.toContain("Search failed:");
+  });
+
   test("contexts with implausible file paths are rejected; valid paths from every OS render normally", async () => {
     // Implausible: bare letters, empty strings, whitespace, no separators or extensions
     for (const file of ["C", "", " ", "noextension"]) {

--- a/index.ts
+++ b/index.ts
@@ -982,7 +982,7 @@ Get your API key at: https://morphllm.com/dashboard/api-keys`;
             for (;;) {
               const { value, done } = await generator.next();
               if (done) {
-                result = value;
+                result = await value;
                 break;
               }
               turnCount = value.turn;


### PR DESCRIPTION
Closes #9.

## Summary
- Await the final value from streamed `WarpGrepClient.execute()` before formatting the result.
- Add a regression test for promised final WarpGrep results so the plugin does not format the promise as a failed search.

## Tests
- `bun test`
- `bun run build`
- `bun run typecheck`
- `bun run ci`
- Live local sanity check with `warpgrep_codebase_search` against this repo returned 1 context instead of the issue failure.