### PR TITLE
fix: avoid Bun file IO in morph_edit

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -1089,6 +1089,14 @@ describe("ToolContext path resolution", () => {
       rmSync(tempRoot, { recursive: true, force: true });
     }
   });
+
+  test("morph_edit file IO avoids Bun runtime globals", () => {
+    const source = readFileSync(join(import.meta.dir, "index.ts"), "utf-8");
+
+    expect(source).toContain('from "node:fs/promises"');
+    expect(source).not.toContain("Bun.file");
+    expect(source).not.toContain("Bun.write");
+  });
 });
 
 describe("formatWarpGrepResult edge cases", () => {

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ import { type Plugin, tool } from "@opencode-ai/plugin";
 import { MorphClient, WarpGrepClient, CompactClient } from "@morphllm/morphsdk";
 import type { WarpGrepResult, CompactResult } from "@morphllm/morphsdk";
 import type { Part, TextPart, ToolPart, Message } from "@opencode-ai/sdk";
+import { readFile, writeFile } from "node:fs/promises";
 import { isAbsolute, resolve as resolvePath } from "node:path";
 
 // API key from MORPH_API_KEY env var, or the `morph.apiKey` field in
@@ -367,6 +368,14 @@ function resolveSessionFilepath(
   return isAbsolute(targetFilepath)
     ? targetFilepath
     : resolvePath(sessionDirectory, targetFilepath);
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as { code?: string }).code === "ENOENT"
+  );
 }
 
 function resolveSessionRepoRoot(
@@ -952,19 +961,25 @@ Alternatively, use the native 'edit' tool for this change.`;
           // Read the original file
           let originalCode: string;
           try {
-            const file = Bun.file(filepath);
-            if (!(await file.exists())) {
-              if (!normalizedCodeEdit.includes(EXISTING_CODE_MARKER)) {
-                await Bun.write(filepath, normalizedCodeEdit);
-                return `Created new file: ${target_filepath}\n\nLines: ${normalizedCodeEdit.split("\n").length}`;
-              }
-              return `Error: File not found: ${target_filepath}
+            originalCode = await readFile(filepath, "utf8");
+          } catch (err) {
+            if (isFileNotFoundError(err)) {
+              if (normalizedCodeEdit.includes(EXISTING_CODE_MARKER)) {
+                return `Error: File not found: ${target_filepath}
 
 The file doesn't exist and the code_edit contains lazy markers.
 For new files, provide the complete content without "${EXISTING_CODE_MARKER}" markers.`;
+              }
+
+              try {
+                await writeFile(filepath, normalizedCodeEdit, "utf8");
+              } catch (writeErr) {
+                const error = writeErr as Error;
+                return `Error writing file ${target_filepath}: ${error.message}`;
+              }
+              return `Created new file: ${target_filepath}\n\nLines: ${normalizedCodeEdit.split("\n").length}`;
             }
-            originalCode = await file.text();
-          } catch (err) {
+
             const error = err as Error;
             return `Error reading file ${target_filepath}: ${error.message}`;
           }
@@ -1072,7 +1087,7 @@ Options:
 
           // Write the merged result
           try {
-            await Bun.write(filepath, mergedCode);
+            await writeFile(filepath, mergedCode, "utf8");
           } catch (err) {
             const error = err as Error;
             return `Error writing file ${target_filepath}: ${error.message}`;


### PR DESCRIPTION
## Summary

Fixes #29.

`morph_edit` now uses Node `fs/promises` for local file reads and writes instead of `Bun.file` / `Bun.write`. This keeps the Morph SDK calls, tool names, WarpGrep tools, and compaction hooks unchanged while allowing the plugin to run in OpenCode Desktop / Node-style plugin runtimes that do not expose a global `Bun` object.

## Root cause

The plugin is built as a JavaScript package for OpenCode, but the `morph_edit` implementation directly referenced Bun runtime globals for file IO. In OpenCode Desktop, the plugin can execute in an Electron/Node environment where `Bun` is not defined, so `morph_edit` could fail before reaching the Morph API.

## Changes

- Replace `Bun.file(...).text()` with `readFile(..., "utf8")`.
- Replace `Bun.write(...)` with `writeFile(..., "utf8")`.
- Preserve the existing missing-file behavior for complete new-file content vs. lazy-marker edits.
- Add a regression test that keeps `morph_edit` file IO from reintroducing `Bun.file` / `Bun.write`.

## Validation

- `bun test index.test.ts -t 'morph_edit'`
- `bun test`
- `bun run typecheck`
- `bun run build`
- `bun run ci`
- `npm pack --dry-run`
- `git diff --check`
